### PR TITLE
Refresh

### DIFF
--- a/src/AasCore.Aas3_0_RC02/types.cs
+++ b/src/AasCore.Aas3_0_RC02/types.cs
@@ -10061,12 +10061,6 @@ namespace AasCore.Aas3_0_RC02
         {
             return transformer.Transform(this, context);
         }
-
-        public DataSpecificationContent()
-        {
-            // Intentionally empty.
-
-        }
     }
 
     /// <summary>

--- a/src/AasCore.Aas3_0_RC02/xmlization.cs
+++ b/src/AasCore.Aas3_0_RC02/xmlization.cs
@@ -15142,13 +15142,12 @@ namespace AasCore.Aas3_0_RC02
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.DataSpecificationContent? DataSpecificationContentFromSequence(
+            internal static Aas.DataSpecificationContent DataSpecificationContentFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
             {
                 error = null;
-
                 return new Aas.DataSpecificationContent();
             }  // internal static Aas.DataSpecificationContent? DataSpecificationContentFromSequence
 
@@ -15193,7 +15192,7 @@ namespace AasCore.Aas3_0_RC02
                 // Skip the element node and go to the content
                 reader.Read();
 
-                Aas.DataSpecificationContent? result = (
+                Aas.DataSpecificationContent result = (
                     DataSpecificationContentFromSequence(
                         reader,
                         isEmptyElement,
@@ -20915,6 +20914,7 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedParameter.Local")]
             private void DataSpecificationContentToSequence(
                 DataSpecificationContent that,
                 WrappedXmlWriter writer)


### PR DESCRIPTION
Empty constructor is redundant. The compiler generates the same by
default.

We also propagate changes related to xmlization.

aas-core-codegen 75bb208