### PR TITLE
Fix coveralls step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,6 @@ jobs:
         working-directory: src
         run: dotnet tool restore
 
-      - name: Install coveralls.net (to send test coverage)
-        if: github.repository == 'aas-core-works/aas-core3.0rc02-csharp' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: src
-        run: dotnet tool install coveralls.net --version 3.0.0
-
       - name: Check
         working-directory: src
         run: powershell .\Check.ps1

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -31,9 +31,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="9320e216-0e07-4101-8ce3-cd62bc1769d1" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideEnvironment.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_environment.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClasses.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.github/workflows/ci.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/ci.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />


### PR DESCRIPTION
We were installing a wrong version of coveralls.net so the remote CI was
unnecessarily failing. This patch installs the coveralls throught
manifest, as is customary.