### PR TITLE
Test for `null` in jsonization

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -31,7 +31,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="9320e216-0e07-4101-8ce3-cd62bc1769d1" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs
@@ -130,7 +130,8 @@ namespace AasCore.Aas3_0_RC02.Tests
             {
                 "TypeViolation",
                 "RequiredViolation",
-                "EnumViolation"
+                "EnumViolation",
+                "NullViolation"
             };
 
             var paths = new List<string>();

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AdministrativeInformation/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AdministrativeInformation/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "assetAdministrationShells": [
+    {
+      "administration": {
+        "dataSpecifications": [
+          null
+        ]
+      },
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/annotations_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/annotations_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "annotations": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/dataSpecifications_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/extensions_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/first_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/first_value.json
@@ -1,0 +1,23 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": null,
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/qualifiers_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "qualifiers": [
+            null
+          ],
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/second_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/second_value.json
@@ -1,0 +1,23 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/supplementalSemanticIds_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/assetInformation_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/assetInformation_value.json
@@ -1,0 +1,9 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": null,
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/dataSpecifications_item.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "dataSpecifications": [
+        null
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/extensions_item.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        null
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/id_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/id_value.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": null,
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/submodels_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetAdministrationShell/submodels_item.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell",
+      "submodels": [
+        null
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetInformation/assetKind_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/AssetInformation/assetKind_value.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": null
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/dataSpecifications_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/direction_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/direction_value.json
@@ -1,0 +1,28 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": null,
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/extensions_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "extensions": [
+            null
+          ],
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/observed_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/observed_value.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": null,
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/qualifiers_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "qualifiers": [
+            null
+          ],
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/state_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/state_value.json
@@ -1,0 +1,28 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/BasicEventElement/supplementalSemanticIds_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/contentType_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/contentType_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": null,
+          "modelType": "Blob"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Blob"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "extensions": [
+            null
+          ],
+          "modelType": "Blob"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "Blob",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Blob/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "Blob",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Capability"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Capability"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Capability",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Capability/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Capability",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/dataSpecifications_item.json
@@ -1,0 +1,11 @@
+{
+  "conceptDescriptions": [
+    {
+      "dataSpecifications": [
+        null
+      ],
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/extensions_item.json
@@ -1,0 +1,11 @@
+{
+  "conceptDescriptions": [
+    {
+      "extensions": [
+        null
+      ],
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/id_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/id_value.json
@@ -1,0 +1,8 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": null,
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/isCaseOf_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ConceptDescription/isCaseOf_item.json
@@ -1,0 +1,11 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_random_7d1e962e",
+      "isCaseOf": [
+        null
+      ],
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/DataSpecification/dataSpecificationContent_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/DataSpecification/dataSpecificationContent_value.json
@@ -1,0 +1,8 @@
+{
+  "dataSpecifications": [
+    {
+      "dataSpecificationContent": null,
+      "id": "something_random_aa1a03ab"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/DataSpecification/id_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/DataSpecification/id_value.json
@@ -1,0 +1,8 @@
+{
+  "dataSpecifications": [
+    {
+      "dataSpecificationContent": {},
+      "id": null
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/entityType_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/entityType_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": null,
+          "modelType": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "extensions": [
+            null
+          ],
+          "modelType": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/statements_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/statements_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity",
+          "statements": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Entity/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/assetAdministrationShells_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/assetAdministrationShells_item.json
@@ -1,0 +1,5 @@
+{
+  "assetAdministrationShells": [
+    null
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/conceptDescriptions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/conceptDescriptions_item.json
@@ -1,0 +1,5 @@
+{
+  "conceptDescriptions": [
+    null
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/dataSpecifications_item.json
@@ -1,0 +1,5 @@
+{
+  "dataSpecifications": [
+    null
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/submodels_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Environment/submodels_item.json
@@ -1,0 +1,5 @@
+{
+  "submodels": [
+    null
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Extension/name_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Extension/name_value.json
@@ -1,0 +1,17 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": null,
+          "valueType": "xs:boolean"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Extension/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Extension/supplementalSemanticIds_item.json
@@ -1,0 +1,20 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "valueType": "xs:boolean"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/contentType_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/contentType_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": null,
+          "modelType": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "extensions": [
+            null
+          ],
+          "modelType": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "File",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/File/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "File",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Key/type_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Key/type_value.json
@@ -1,0 +1,20 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "derivedFrom": {
+        "keys": [
+          {
+            "type": null,
+            "value": "something_random_44e7dc4a"
+          }
+        ],
+        "type": "GlobalReference"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Key/value_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Key/value_value.json
@@ -1,0 +1,20 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "derivedFrom": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": null
+          }
+        ],
+        "type": "GlobalReference"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangString/language_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangString/language_value.json
@@ -1,0 +1,19 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "displayName": {
+        "langStrings": [
+          {
+            "language": null,
+            "text": "something_random_6ad1965e"
+          }
+        ]
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangString/text_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangString/text_value.json
@@ -1,0 +1,19 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "displayName": {
+        "langStrings": [
+          {
+            "language": "en",
+            "text": null
+          }
+        ]
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangStringSet/langStrings_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangStringSet/langStrings_item.json
@@ -1,0 +1,16 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "displayName": {
+        "langStrings": [
+          null
+        ]
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangStringSet/langStrings_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/LangStringSet/langStrings_value.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "displayName": {
+        "langStrings": null
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "MultiLanguageProperty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "MultiLanguageProperty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "MultiLanguageProperty",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/MultiLanguageProperty/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "MultiLanguageProperty",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/inoutputVariables_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/inoutputVariables_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "inoutputVariables": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/inputVariables_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/inputVariables_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "inputVariables": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/outputVariables_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/outputVariables_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Operation",
+          "outputVariables": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Operation",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Operation/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Operation",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/OperationVariable/value_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/OperationVariable/value_value.json
@@ -1,0 +1,18 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "inputVariables": [
+            {
+              "value": null
+            }
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Property",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Property",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Property",
+          "qualifiers": [
+            null
+          ],
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Property",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/valueType_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Property/valueType_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Property",
+          "valueType": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Qualifier/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Qualifier/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "supplementalSemanticIds": [
+            null
+          ],
+          "type": "something_random_cfd39ba4",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Qualifier/type_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Qualifier/type_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": null,
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Qualifier/valueType_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Qualifier/valueType_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "valueType": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Range",
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Range",
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Range",
+          "qualifiers": [
+            null
+          ],
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Range",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/valueType_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Range/valueType_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Range",
+          "valueType": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Reference/keys_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Reference/keys_item.json
@@ -1,0 +1,17 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "derivedFrom": {
+        "keys": [
+          null
+        ],
+        "type": "GlobalReference"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Reference/keys_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Reference/keys_value.json
@@ -1,0 +1,15 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "derivedFrom": {
+        "keys": null,
+        "type": "GlobalReference"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Reference/type_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Reference/type_value.json
@@ -1,0 +1,20 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "derivedFrom": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": "something_random_44e7dc4a"
+          }
+        ],
+        "type": null
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "ReferenceElement"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "ReferenceElement"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "ReferenceElement",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/ReferenceElement/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "ReferenceElement",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/dataSpecifications_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/extensions_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/first_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/first_value.json
@@ -1,0 +1,23 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": null,
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/qualifiers_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "qualifiers": [
+            null
+          ],
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/second_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/second_value.json
@@ -1,0 +1,23 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/RelationshipElement/supplementalSemanticIds_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Resource/path_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Resource/path_value.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance",
+        "defaultThumbnail": {
+          "path": null
+        }
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/externalSubjectId_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/externalSubjectId_value.json
@@ -1,0 +1,16 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance",
+        "specificAssetId": {
+          "externalSubjectId": null,
+          "name": "something_random_73ff3355",
+          "value": "something_random_d43e0a3b"
+        }
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/name_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/name_value.json
@@ -1,0 +1,24 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance",
+        "specificAssetId": {
+          "externalSubjectId": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_ecd20100"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "name": null,
+          "value": "something_random_d43e0a3b"
+        }
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/supplementalSemanticIds_item.json
@@ -1,0 +1,27 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance",
+        "specificAssetId": {
+          "externalSubjectId": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_ecd20100"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "name": "something_random_73ff3355",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "value": "something_random_d43e0a3b"
+        }
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/value_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SpecificAssetId/value_value.json
@@ -1,0 +1,24 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance",
+        "specificAssetId": {
+          "externalSubjectId": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_ecd20100"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "name": "something_random_73ff3355",
+          "value": null
+        }
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/dataSpecifications_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "dataSpecifications": [
+        null
+      ],
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/extensions_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "extensions": [
+        null
+      ],
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/id_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/id_value.json
@@ -1,0 +1,8 @@
+{
+  "submodels": [
+    {
+      "id": null,
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/qualifiers_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        null
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/submodelElements_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/submodelElements_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        null
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/Submodel/supplementalSemanticIds_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "supplementalSemanticIds": [
+        null
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementCollection",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementCollection",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/value_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementCollection/value_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementCollection",
+          "value": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/dataSpecifications_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/extensions_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/qualifiers_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "qualifiers": [
+            null
+          ],
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/supplementalSemanticIds_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/typeValueListElement_value.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/typeValueListElement_value.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/value_item.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/NullViolation/SubmodelElementList/value_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": "SubmodelElementCollection",
+          "value": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/assetAdministrationShells.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/assetAdministrationShells.json
@@ -1,0 +1,21 @@
+{
+  "assetAdministrationShells": "Unexpected string value",
+  "conceptDescriptions": [
+    {
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ],
+  "dataSpecifications": [
+    {
+      "dataSpecificationContent": {},
+      "id": "something_random_aa1a03ab"
+    }
+  ],
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/conceptDescriptions.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/conceptDescriptions.json
@@ -1,0 +1,24 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ],
+  "conceptDescriptions": "Unexpected string value",
+  "dataSpecifications": [
+    {
+      "dataSpecificationContent": {},
+      "id": "something_random_aa1a03ab"
+    }
+  ],
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/dataSpecifications.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/dataSpecifications.json
@@ -1,0 +1,24 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ],
+  "conceptDescriptions": [
+    {
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ],
+  "dataSpecifications": "Unexpected string value",
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/submodels.json
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Json/Unexpected/TypeViolation/Environment/submodels.json
@@ -1,0 +1,24 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ],
+  "conceptDescriptions": [
+    {
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ],
+  "dataSpecifications": [
+    {
+      "dataSpecificationContent": {},
+      "id": "something_random_aa1a03ab"
+    }
+  ],
+  "submodels": "Unexpected string value"
+}

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/assetAdministrationShells.xml
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/assetAdministrationShells.xml
@@ -1,0 +1,19 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>Unexpected string value</assetAdministrationShells>
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+		</submodel>
+	</submodels>
+	<conceptDescriptions>
+		<conceptDescription>
+			<id>something_random_7d1e962e</id>
+		</conceptDescription>
+	</conceptDescriptions>
+	<dataSpecifications>
+		<dataSpecification>
+			<id>something_random_aa1a03ab</id>
+			<dataSpecificationContent/>
+		</dataSpecification>
+	</dataSpecifications>
+</environment>

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/conceptDescriptions.xml
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/conceptDescriptions.xml
@@ -1,0 +1,22 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+		</submodel>
+	</submodels>
+	<conceptDescriptions>Unexpected string value</conceptDescriptions>
+	<dataSpecifications>
+		<dataSpecification>
+			<id>something_random_aa1a03ab</id>
+			<dataSpecificationContent/>
+		</dataSpecification>
+	</dataSpecifications>
+</environment>

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/dataSpecifications.xml
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/dataSpecifications.xml
@@ -1,0 +1,21 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+		</submodel>
+	</submodels>
+	<conceptDescriptions>
+		<conceptDescription>
+			<id>something_random_7d1e962e</id>
+		</conceptDescription>
+	</conceptDescriptions>
+	<dataSpecifications>Unexpected string value</dataSpecifications>
+</environment>

--- a/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/submodels.xml
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestResources/AasCore.Aas3_0_RC02.Tests/Xml/Unexpected/TypeViolation/environment/submodels.xml
@@ -1,0 +1,22 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+	<submodels>Unexpected string value</submodels>
+	<conceptDescriptions>
+		<conceptDescription>
+			<id>something_random_7d1e962e</id>
+		</conceptDescription>
+	</conceptDescriptions>
+	<dataSpecifications>
+		<dataSpecification>
+			<id>something_random_aa1a03ab</id>
+			<dataSpecificationContent/>
+		</dataSpecification>
+	</dataSpecifications>
+</environment>

--- a/src/AasCore.Aas3_0_RC02/jsonization.cs
+++ b/src/AasCore.Aas3_0_RC02/jsonization.cs
@@ -376,6 +376,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -1053,6 +1054,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -1321,6 +1323,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -1514,6 +1517,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -1714,6 +1718,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -1809,6 +1814,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2133,6 +2139,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2286,6 +2293,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2528,6 +2536,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2579,6 +2588,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2630,6 +2640,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2681,6 +2692,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodelElements"));
+                            return null;
                         }
                         ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -2926,6 +2938,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3124,6 +3137,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3175,6 +3189,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3226,6 +3241,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3362,6 +3378,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3560,6 +3577,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3611,6 +3629,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3662,6 +3681,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3734,6 +3754,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
+                            return null;
                         }
                         ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -3890,6 +3911,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4088,6 +4110,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4139,6 +4162,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4190,6 +4214,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4241,6 +4266,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
+                            return null;
                         }
                         ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4398,6 +4424,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4596,6 +4623,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4647,6 +4675,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4698,6 +4727,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -4852,6 +4882,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5050,6 +5081,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5101,6 +5133,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5152,6 +5185,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5280,6 +5314,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5478,6 +5513,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5529,6 +5565,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5580,6 +5617,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5734,6 +5772,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5932,6 +5971,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -5983,6 +6023,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6034,6 +6075,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6140,6 +6182,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6338,6 +6381,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6389,6 +6433,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6440,6 +6485,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6572,6 +6618,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6770,6 +6817,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6821,6 +6869,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -6872,6 +6921,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7004,6 +7054,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7202,6 +7253,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7253,6 +7305,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7304,6 +7357,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7401,6 +7455,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "annotations"));
+                            return null;
                         }
                         IDataElement? parsedItem = DeserializeImplementation.IDataElementFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7522,6 +7577,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7720,6 +7776,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7771,6 +7828,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7822,6 +7880,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -7873,6 +7932,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "statements"));
+                            return null;
                         }
                         ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -8355,6 +8415,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -8553,6 +8614,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -8604,6 +8666,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -8655,6 +8718,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -8927,6 +8991,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9125,6 +9190,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9176,6 +9242,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9227,6 +9294,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9278,6 +9346,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inputVariables"));
+                            return null;
                         }
                         OperationVariable? parsedItem = DeserializeImplementation.OperationVariableFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9329,6 +9398,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "outputVariables"));
+                            return null;
                         }
                         OperationVariable? parsedItem = DeserializeImplementation.OperationVariableFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9380,6 +9450,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inoutputVariables"));
+                            return null;
                         }
                         OperationVariable? parsedItem = DeserializeImplementation.OperationVariableFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9515,6 +9586,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9713,6 +9785,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "supplementalSemanticIds"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9764,6 +9837,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
+                            return null;
                         }
                         Qualifier? parsedItem = DeserializeImplementation.QualifierFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9815,6 +9889,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -9899,6 +9974,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
+                            return null;
                         }
                         Extension? parsedItem = DeserializeImplementation.ExtensionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -10099,6 +10175,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -10150,6 +10227,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "isCaseOf"));
+                            return null;
                         }
                         Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -10312,6 +10390,7 @@ namespace AasCore.Aas3_0_RC02
                         error.PrependSegment(
                             new Reporting.NameSegment(
                                 "keys"));
+                        return null;
                     }
                     Key? parsedItem = DeserializeImplementation.KeyFrom(
                         item ?? throw new System.InvalidOperationException(),
@@ -10872,6 +10951,7 @@ namespace AasCore.Aas3_0_RC02
                         error.PrependSegment(
                             new Reporting.NameSegment(
                                 "langStrings"));
+                        return null;
                     }
                     LangString? parsedItem = DeserializeImplementation.LangStringFrom(
                         item ?? throw new System.InvalidOperationException(),
@@ -11087,6 +11167,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "assetAdministrationShells"));
+                            return null;
                         }
                         AssetAdministrationShell? parsedItem = DeserializeImplementation.AssetAdministrationShellFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -11138,6 +11219,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
+                            return null;
                         }
                         Submodel? parsedItem = DeserializeImplementation.SubmodelFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -11189,6 +11271,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "conceptDescriptions"));
+                            return null;
                         }
                         ConceptDescription? parsedItem = DeserializeImplementation.ConceptDescriptionFrom(
                             item ?? throw new System.InvalidOperationException(),
@@ -11240,6 +11323,7 @@ namespace AasCore.Aas3_0_RC02
                             error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
+                            return null;
                         }
                         DataSpecification? parsedItem = DeserializeImplementation.DataSpecificationFrom(
                             item ?? throw new System.InvalidOperationException(),


### PR DESCRIPTION
We add test cases for `null` in JSON. This revealed a bug which we fixed
in aas-core-codegen.

[aas-core-codegen e0afd91]
[aas-core3.0rc02-testgen caa21a4e]

[aas-core-codegen e0afd91]: https://github.com/aas-core-works/aas-core-codegen/commit/e0afd91
[aas-core3.0rc02-testgen caa21a4e]: https://github.com/aas-core-works/aas-core3.0rc02-testgen/commit/caa21a4e