### PR TITLE
Exclude test resources from InspectCode

### DIFF
--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -26,7 +26,7 @@ function Main
         "--properties:Configuration=DebugSlow" `
         "-o=$codeInspectionPath" `
         "--caches-home=$cachesHome" `
-        '--exclude=*\obj\*;packages\*;*\bin\*;*\*.json;*\TestResources\*' `
+        '--exclude=**\obj\**\*.*;packages\**\*.*;**\bin\**\*.*;**\*.json;**\TestResources\**\*.*' `
         "--build" `
         aas-core3.0rc02-csharp.sln
 


### PR DESCRIPTION
The test resources cluttered the output of the InspectCode too much, but
were not really verified in any meaningful manner.