### PR TITLE
Unify test code

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -31,11 +31,20 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="9320e216-0e07-4101-8ce3-cd62bc1769d1" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClassesOutsideEnvironment.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/testgen/generate_test_for_xmlization_of_concrete_classes_outside_environment.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/Common.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/Common.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClasses.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClassesThroughEnvironment.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestDescendOnce.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestDescendOnce.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideEnvironment.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideEnvironment.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfInterfaces.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfInterfaces.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_all.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_all.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_environment.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_environment.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_interfaces.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_interfaces.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_xmlization_of_interfaces.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_xmlization_of_interfaces.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -74,7 +83,28 @@
       <recent name="C:\Users\rist\workspace\aas-core-works\aas-core3.0rc02-csharp\src" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.generate_test_for_xmlization_of_concrete_classes_outside_environment">
+  <component name="RunManager" selected="Python.generate_test_for_xmlization_of_interfaces">
+    <configuration name="generate_all" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="aas-core3.0rc02-csharp" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_all.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
     <configuration name="generate_test_for_jsonization_of_concrete_classes_outside_environment" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="aas-core3.0rc02-csharp" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -88,27 +118,6 @@
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
       <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_environment.py" />
-      <option name="PARAMETERS" value="" />
-      <option name="SHOW_COMMAND_LINE" value="false" />
-      <option name="EMULATE_TERMINAL" value="false" />
-      <option name="MODULE_MODE" value="false" />
-      <option name="REDIRECT_INPUT" value="false" />
-      <option name="INPUT_FILE" value="" />
-      <method v="2" />
-    </configuration>
-    <configuration name="generate_test_for_jsonization_of_enums" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
-      <module name="aas-core3.0rc02-csharp" />
-      <option name="INTERPRETER_OPTIONS" value="" />
-      <option name="PARENT_ENVS" value="true" />
-      <envs>
-        <env name="PYTHONUNBUFFERED" value="1" />
-      </envs>
-      <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
-      <option name="IS_MODULE_SDK" value="true" />
-      <option name="ADD_CONTENT_ROOTS" value="true" />
-      <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_enums.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -182,11 +191,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Python.generate_test_for_xmlization_of_interfaces" />
+        <item itemvalue="Python.generate_all" />
         <item itemvalue="Python.generate_test_for_xmlization_of_concrete_classes_outside_environment" />
         <item itemvalue="Python.generate_test_verification_of_enums" />
         <item itemvalue="Python.generate_test_for_jsonization_of_concrete_classes_outside_environment" />
-        <item itemvalue="Python.generate_test_for_jsonization_of_enums" />
-        <item itemvalue="Python.generate_test_for_xmlization_of_interfaces" />
       </list>
     </recent_temporary>
   </component>

--- a/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs
@@ -5,14 +5,14 @@ using Path = System.IO.Path;
 using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
     public class TestDescendAndVisitorThrough
     {
         private static readonly string JsonExpectedDir = Path.Combine(
-            AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+            Aas.Tests.Common.OurTestResourceDir,
             "Json",
             "Expected");
 
@@ -73,8 +73,8 @@ namespace AasCore.Aas3_0_RC02.Tests
         {
             foreach (string pathToCompleteExample in PathsToCompleteExamples())
             {
-                IClass? environment = AasCore.Aas3_0_RC02.Jsonization.Deserialize.EnvironmentFrom(
-                    AasCore.Aas3_0_RC02.Tests.CommonJson.ReadFromFile(
+                IClass? environment = Aas.Jsonization.Deserialize.EnvironmentFrom(
+                    Aas.Tests.CommonJson.ReadFromFile(
                         pathToCompleteExample));
 
                 if (environment == null)
@@ -110,13 +110,13 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_against_the_recorded()
         {
             string recordingBaseDir = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Descend");
 
             foreach (string pathToCompleteExample in PathsToCompleteExamples())
             {
-                IClass? environment = AasCore.Aas3_0_RC02.Jsonization.Deserialize.EnvironmentFrom(
-                    AasCore.Aas3_0_RC02.Tests.CommonJson.ReadFromFile(
+                IClass? environment = Aas.Jsonization.Deserialize.EnvironmentFrom(
+                    Aas.Tests.CommonJson.ReadFromFile(
                         pathToCompleteExample));
 
                 if (environment == null)
@@ -139,7 +139,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 var expectedPath = Path.Join(
                     recordingBaseDir, relativePath + ".trace");
 
-                if (AasCore.Aas3_0_RC02.Tests.Common.RecordMode)
+                if (Aas.Tests.Common.RecordMode)
                 {
                     string? parent = Path.GetDirectoryName(expectedPath);
                     if (parent != null)

--- a/src/AasCore.Aas3_0_RC02.Tests/TestDescendOnce.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestDescendOnce.cs
@@ -6,8 +6,9 @@
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
-using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
+
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -44,7 +45,7 @@ namespace AasCore.Aas3_0_RC02.Tests
 
             string got = writer.ToString();
 
-            if (AasCore.Aas3_0_RC02.Tests.Common.RecordMode)
+            if (Aas.Tests.Common.RecordMode)
             {
                 string? parent = Path.GetDirectoryName(expectedPath);
                 if (parent != null)
@@ -77,29 +78,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Extension()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Extension",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Extension)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Extension)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Extension could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Extension>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Extension",
                     "complete.json.trace"));
@@ -109,29 +103,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_AdministrativeInformation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AdministrativeInformation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AdministrativeInformation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AdministrativeInformation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AdministrativeInformation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AdministrativeInformation>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "AdministrativeInformation",
                     "complete.json.trace"));
@@ -141,29 +128,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Qualifier()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Qualifier",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Qualifier)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Qualifier)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Qualifier could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Qualifier>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Qualifier",
                     "complete.json.trace"));
@@ -173,29 +153,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_AssetAdministrationShell()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetAdministrationShell)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "AssetAdministrationShell",
                     "complete.json.trace"));
@@ -205,29 +178,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_AssetInformation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetInformation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetInformation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetInformation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetInformation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetInformation>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "AssetInformation",
                     "complete.json.trace"));
@@ -237,29 +203,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Resource()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Resource",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Resource)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Resource)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Resource could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Resource>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Resource",
                     "complete.json.trace"));
@@ -269,29 +228,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SpecificAssetId()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SpecificAssetId",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SpecificAssetId)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SpecificAssetId)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SpecificAssetId could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SpecificAssetId>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "SpecificAssetId",
                     "complete.json.trace"));
@@ -301,29 +253,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Submodel",
                     "complete.json.trace"));
@@ -333,61 +278,72 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "RelationshipElement",
                     "complete.json.trace"));
         }  // public void Test_RelationshipElement
 
         [Test]
+        public void Test_SubmodelElementList()
+        {
+            string pathToCompleteExample = Path.Combine(
+                Aas.Tests.Common.OurTestResourceDir,
+                "Json",
+                "Expected",
+                "SubmodelElementList",
+                "complete.json");
+
+            var container = Aas.Tests.CommonJson.LoadInstance(
+                pathToCompleteExample);
+
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
+
+            CompareOrRerecordTrace(
+                instance,
+                Path.Combine(
+                    Aas.Tests.Common.OurTestResourceDir,
+                    "DescendOnce",
+                    "SubmodelElementList",
+                    "complete.json.trace"));
+        }  // public void Test_SubmodelElementList
+
+        [Test]
         public void Test_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "SubmodelElementCollection",
                     "complete.json.trace"));
@@ -397,29 +353,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Property",
                     "complete.json.trace"));
@@ -429,29 +378,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "MultiLanguageProperty",
                     "complete.json.trace"));
@@ -461,29 +403,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Range",
                     "complete.json.trace"));
@@ -493,29 +428,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "ReferenceElement",
                     "complete.json.trace"));
@@ -525,29 +453,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Blob",
                     "complete.json.trace"));
@@ -557,29 +478,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "File",
                     "complete.json.trace"));
@@ -589,29 +503,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "AnnotatedRelationshipElement",
                     "complete.json.trace"));
@@ -621,29 +528,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Entity",
                     "complete.json.trace"));
@@ -653,29 +553,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "BasicEventElement",
                     "complete.json.trace"));
@@ -685,29 +578,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Operation",
                     "complete.json.trace"));
@@ -717,29 +603,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_OperationVariable()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "OperationVariable",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is OperationVariable)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is OperationVariable)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of OperationVariable could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.OperationVariable>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "OperationVariable",
                     "complete.json.trace"));
@@ -749,29 +628,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Capability",
                     "complete.json.trace"));
@@ -781,29 +653,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ConceptDescription()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "ConceptDescription",
                     "complete.json.trace"));
@@ -813,29 +678,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Reference()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Reference",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Reference)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Reference)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Reference could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Reference>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Reference",
                     "complete.json.trace"));
@@ -845,29 +703,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Key()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Key",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Key)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Key)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Key could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Key>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Key",
                     "complete.json.trace"));
@@ -877,29 +728,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_LangString()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "LangString",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is LangString)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is LangString)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of LangString could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.LangString>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "LangString",
                     "complete.json.trace"));
@@ -909,29 +753,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_LangStringSet()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "LangStringSet",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is LangStringSet)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is LangStringSet)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of LangStringSet could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.LangStringSet>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "LangStringSet",
                     "complete.json.trace"));
@@ -941,29 +778,22 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Environment()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Environment",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Environment)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Environment)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Environment could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Environment>(
+                container);
 
             CompareOrRerecordTrace(
                 instance,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "DescendOnce",
                     "Environment",
                     "complete.json.trace"));

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideEnvironment.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideEnvironment.cs
@@ -5,10 +5,9 @@
 
 using Path = System.IO.Path;
 
-using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -18,24 +17,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Extension()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Extension",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Extension)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Extension)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Extension could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Extension>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -45,7 +37,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -65,24 +57,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_AdministrativeInformation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AdministrativeInformation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AdministrativeInformation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AdministrativeInformation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AdministrativeInformation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AdministrativeInformation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -92,7 +77,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -112,24 +97,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Qualifier()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Qualifier",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Qualifier)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Qualifier)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Qualifier could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Qualifier>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -139,7 +117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -159,24 +137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_AssetAdministrationShell()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetAdministrationShell)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -186,7 +157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -206,24 +177,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_AssetInformation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetInformation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetInformation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetInformation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetInformation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetInformation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -233,7 +197,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -253,24 +217,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Resource()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Resource",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Resource)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Resource)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Resource could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Resource>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -280,7 +237,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -300,24 +257,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_SpecificAssetId()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SpecificAssetId",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SpecificAssetId)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SpecificAssetId)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SpecificAssetId could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SpecificAssetId>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -327,7 +277,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -347,24 +297,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -374,7 +317,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -394,24 +337,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -421,7 +357,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -441,24 +377,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -468,7 +397,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -488,24 +417,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -515,7 +437,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -535,24 +457,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -562,7 +477,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -582,24 +497,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -609,7 +517,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -629,24 +537,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -656,7 +557,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -676,24 +577,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -703,7 +597,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -723,24 +617,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -750,7 +637,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -770,24 +657,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -797,7 +677,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -817,24 +697,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -844,7 +717,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -864,24 +737,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -891,7 +757,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -911,24 +777,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -938,7 +797,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -958,24 +817,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -985,7 +837,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1005,24 +857,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_OperationVariable()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "OperationVariable",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is OperationVariable)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is OperationVariable)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of OperationVariable could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.OperationVariable>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1032,7 +877,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1052,24 +897,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1079,7 +917,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1099,24 +937,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ConceptDescription()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1126,7 +957,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1146,24 +977,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Reference()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Reference",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Reference)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Reference)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Reference could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Reference>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1173,7 +997,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1193,24 +1017,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Key()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Key",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Key)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Key)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Key could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Key>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1220,7 +1037,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1240,24 +1057,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_LangString()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "LangString",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is LangString)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is LangString)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of LangString could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.LangString>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1267,7 +1077,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1287,24 +1097,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_LangStringSet()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "LangStringSet",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is LangStringSet)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is LangStringSet)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of LangStringSet could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.LangStringSet>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1314,7 +1117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1334,24 +1137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_Environment()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Environment",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Environment)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Environment)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Environment could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Environment>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1361,7 +1157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesThroughEnvironment.cs
@@ -1,10 +1,13 @@
 using Directory = System.IO.Directory;
 using Nodes = System.Text.Json.Nodes;
 using Path = System.IO.Path;
-using System.Collections.Generic;
+
+using System.Collections.Generic;  // can't alias
 using System.IO; // can't alias
 using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
+
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -17,7 +20,7 @@ namespace AasCore.Aas3_0_RC02.Tests
         private static IEnumerable<string> ExpectedPaths()
         {
             string expectedDir = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected");
 
@@ -44,13 +47,13 @@ namespace AasCore.Aas3_0_RC02.Tests
             foreach (string path in ExpectedPaths())
             {
                 var originalNode = Aas3_0_RC02.Tests.CommonJson.ReadFromFile(path);
-                AasCore.Aas3_0_RC02.Environment? instance = null;
+                Aas.Environment? instance = null;
                 try
                 {
-                    instance = AasCore.Aas3_0_RC02.Jsonization.Deserialize.EnvironmentFrom(
+                    instance = Aas.Jsonization.Deserialize.EnvironmentFrom(
                         originalNode);
                 }
-                catch (AasCore.Aas3_0_RC02.Jsonization.Exception exception)
+                catch (Aas.Jsonization.Exception exception)
                 {
                     Assert.Fail(
                         "Expected no exception upon de-serialization of an environment " +
@@ -66,7 +69,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                     );
                 }
 
-                var errors = AasCore.Aas3_0_RC02.Verification.Verify(instance).ToList();
+                var errors = Aas.Verification.Verify(instance).ToList();
                 if (errors.Count > 0)
                 {
                     var builder = new System.Text.StringBuilder();
@@ -86,7 +89,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 Nodes.JsonObject? serialized = null;
                 try
                 {
-                    serialized = AasCore.Aas3_0_RC02.Jsonization.Serialize.ToJsonObject(instance);
+                    serialized = Aas.Jsonization.Serialize.ToJsonObject(instance);
                 }
                 catch (System.Exception exception)
                 {
@@ -139,7 +142,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             foreach (string dirName in dirNames)
             {
                 string unexpectedDir = Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "Json",
                     "Unexpected",
                     dirName);
@@ -171,14 +174,14 @@ namespace AasCore.Aas3_0_RC02.Tests
             {
                 var node = Aas3_0_RC02.Tests.CommonJson.ReadFromFile(path);
 
-                AasCore.Aas3_0_RC02.Jsonization.Exception? exception = null;
+                Aas.Jsonization.Exception? exception = null;
 
                 try
                 {
-                    var _ = AasCore.Aas3_0_RC02.Jsonization.Deserialize.EnvironmentFrom(
+                    var _ = Aas.Jsonization.Deserialize.EnvironmentFrom(
                         node);
                 }
-                catch (AasCore.Aas3_0_RC02.Jsonization.Exception observedException)
+                catch (Aas.Jsonization.Exception observedException)
                 {
                     exception = observedException;
                 }
@@ -193,7 +196,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 {
                     string exceptionPath = path + ".exception";
                     string got = exception.Message;
-                    if (AasCore.Aas3_0_RC02.Tests.Common.RecordMode)
+                    if (Aas.Tests.Common.RecordMode)
                     {
                         System.IO.File.WriteAllText(exceptionPath, got);
                     }
@@ -237,7 +240,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             foreach (string dirName in dirNames)
             {
                 string unexpectedDir = Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "Json",
                     "Unexpected",
                     dirName);
@@ -274,13 +277,13 @@ namespace AasCore.Aas3_0_RC02.Tests
             foreach (string path in PathsWithFailedVerifications())
             {
                 var node = Aas3_0_RC02.Tests.CommonJson.ReadFromFile(path);
-                AasCore.Aas3_0_RC02.Environment? instance = null;
+                Aas.Environment? instance = null;
                 try
                 {
-                    instance = AasCore.Aas3_0_RC02.Jsonization.Deserialize.EnvironmentFrom(
+                    instance = Aas.Jsonization.Deserialize.EnvironmentFrom(
                         node);
                 }
-                catch (AasCore.Aas3_0_RC02.Jsonization.Exception exception)
+                catch (Aas.Jsonization.Exception exception)
                 {
                     Assert.Fail(
                         "Expected no exception upon de-serialization of an environment " +
@@ -296,7 +299,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                     );
                 }
 
-                var errors = AasCore.Aas3_0_RC02.Verification.Verify(instance).ToList();
+                var errors = Aas.Verification.Verify(instance).ToList();
                 if (errors.Count == 0)
                 {
                     Assert.Fail(
@@ -309,7 +312,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                         error => $"{Reporting.GenerateJsonPath(error.PathSegments)}: {error.Cause}"));
 
                 string errorsPath = path + ".errors";
-                if (AasCore.Aas3_0_RC02.Tests.Common.RecordMode)
+                if (Aas.Tests.Common.RecordMode)
                 {
                     System.IO.File.WriteAllText(errorsPath, got);
                 }

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs
@@ -7,7 +7,7 @@ using Nodes = System.Text.Json.Nodes;
 
 using NUnit.Framework;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs
@@ -6,9 +6,8 @@
 using Path = System.IO.Path;
 
 using NUnit.Framework;  // can't alias
-using System.Linq; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -18,24 +17,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -45,7 +37,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -65,24 +57,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -92,7 +77,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -112,24 +97,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -139,7 +117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -159,24 +137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -186,7 +157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -206,24 +177,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -233,7 +197,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -253,24 +217,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -280,7 +237,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -300,24 +257,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -327,7 +277,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -347,24 +297,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -374,7 +317,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -394,24 +337,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -421,7 +357,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -441,24 +377,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -468,7 +397,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -488,24 +417,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -515,7 +437,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -535,24 +457,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -562,7 +477,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -582,24 +497,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -609,7 +517,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -629,24 +537,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -656,7 +557,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -676,24 +577,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasSemantics_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -703,7 +597,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -723,24 +617,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -750,7 +637,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -770,24 +657,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -797,7 +677,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -817,24 +697,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_AssetAdministrationShell()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetAdministrationShell)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -844,7 +717,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -864,24 +737,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -891,7 +757,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -911,24 +777,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -938,7 +797,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -958,24 +817,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -985,7 +837,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1005,24 +857,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_ConceptDescription()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1032,7 +877,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1052,24 +897,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1079,7 +917,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1099,24 +937,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1126,7 +957,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1146,24 +977,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1173,7 +997,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1193,24 +1017,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1220,7 +1037,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1240,24 +1057,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1267,7 +1077,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1287,24 +1097,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1314,7 +1117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1334,24 +1137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1361,7 +1157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1381,24 +1177,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1408,7 +1197,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1428,24 +1217,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1455,7 +1237,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1475,24 +1257,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasExtensions_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1502,7 +1277,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1522,24 +1297,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1549,7 +1317,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1569,24 +1337,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1596,7 +1357,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1616,24 +1377,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_AssetAdministrationShell()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetAdministrationShell)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1643,7 +1397,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1663,24 +1417,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1690,7 +1437,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1710,24 +1457,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1737,7 +1477,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1757,24 +1497,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1784,7 +1517,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1804,24 +1537,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_ConceptDescription()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1831,7 +1557,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1851,24 +1577,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1878,7 +1597,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1898,24 +1617,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1925,7 +1637,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1945,24 +1657,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -1972,7 +1677,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -1992,24 +1697,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2019,7 +1717,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2039,24 +1737,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2066,7 +1757,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2086,24 +1777,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2113,7 +1797,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2133,24 +1817,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2160,7 +1837,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2180,24 +1857,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2207,7 +1877,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2227,24 +1897,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2254,7 +1917,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2274,24 +1937,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IReferable_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2301,7 +1957,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2321,24 +1977,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IIdentifiable_from_AssetAdministrationShell()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetAdministrationShell)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2348,7 +1997,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2368,24 +2017,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IIdentifiable_from_ConceptDescription()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2395,7 +2037,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2415,24 +2057,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IIdentifiable_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2442,7 +2077,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2462,24 +2097,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2489,7 +2117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2509,24 +2137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2536,7 +2157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2556,24 +2177,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2583,7 +2197,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2603,24 +2217,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2630,7 +2237,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2650,24 +2257,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2677,7 +2277,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2697,24 +2297,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2724,7 +2317,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2744,24 +2337,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2771,7 +2357,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2791,24 +2377,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2818,7 +2397,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2838,24 +2417,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2865,7 +2437,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2885,24 +2457,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2912,7 +2477,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2932,24 +2497,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -2959,7 +2517,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -2979,24 +2537,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3006,7 +2557,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3026,24 +2577,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3053,7 +2597,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3073,24 +2617,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3100,7 +2637,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3120,24 +2657,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasKind_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3147,7 +2677,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3167,24 +2697,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3194,7 +2717,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3214,24 +2737,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3241,7 +2757,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3261,24 +2777,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_AssetAdministrationShell()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AssetAdministrationShell)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3288,7 +2797,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3308,24 +2817,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3335,7 +2837,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3355,24 +2857,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3382,7 +2877,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3402,24 +2897,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3429,7 +2917,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3449,24 +2937,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_ConceptDescription()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3476,7 +2957,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3496,24 +2977,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3523,7 +2997,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3543,24 +3017,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3570,7 +3037,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3590,24 +3057,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3617,7 +3077,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3637,24 +3097,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3664,7 +3117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3684,24 +3137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3711,7 +3157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3731,24 +3177,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3758,7 +3197,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3778,24 +3217,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3805,7 +3237,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3825,24 +3257,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3852,7 +3277,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3872,24 +3297,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3899,7 +3317,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3919,24 +3337,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IHasDataSpecification_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3946,7 +3357,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -3966,24 +3377,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -3993,7 +3397,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4013,24 +3417,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4040,7 +3437,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4060,24 +3457,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4087,7 +3477,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4107,24 +3497,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4134,7 +3517,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4154,24 +3537,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4181,7 +3557,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4201,24 +3577,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4228,7 +3597,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4248,24 +3617,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4275,7 +3637,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4295,24 +3657,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4322,7 +3677,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4342,24 +3697,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4369,7 +3717,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4389,24 +3737,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4416,7 +3757,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4436,24 +3777,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4463,7 +3797,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4483,24 +3817,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4510,7 +3837,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4530,24 +3857,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_Submodel()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4557,7 +3877,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4577,24 +3897,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4604,7 +3917,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4624,24 +3937,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IQualifiable_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4651,7 +3957,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4671,24 +3977,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4698,7 +3997,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4718,24 +4017,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4745,7 +4037,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4765,24 +4057,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4792,7 +4077,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4812,24 +4097,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4839,7 +4117,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4859,24 +4137,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_Capability()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4886,7 +4157,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4906,24 +4177,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_Entity()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4933,7 +4197,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -4953,24 +4217,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -4980,7 +4237,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5000,24 +4257,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5027,7 +4277,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5047,24 +4297,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_Operation()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5074,7 +4317,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5094,24 +4337,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5121,7 +4357,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5141,24 +4377,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5168,7 +4397,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5188,24 +4417,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5215,7 +4437,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5235,24 +4457,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_SubmodelElementCollection()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5262,7 +4477,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5282,24 +4497,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_ISubmodelElement_from_SubmodelElementList()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5309,7 +4517,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5329,24 +4537,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IRelationshipElement_from_AnnotatedRelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5356,7 +4557,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5376,24 +4577,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IRelationshipElement_from_RelationshipElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5403,7 +4597,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5423,24 +4617,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IDataElement_from_Blob()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5450,7 +4637,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5470,24 +4657,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IDataElement_from_File()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5497,7 +4677,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5517,24 +4697,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IDataElement_from_MultiLanguageProperty()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5544,7 +4717,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5564,24 +4737,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IDataElement_from_Property()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5591,7 +4757,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5611,24 +4777,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IDataElement_from_Range()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5638,7 +4797,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5658,24 +4817,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IDataElement_from_ReferenceElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5685,7 +4837,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);
@@ -5705,24 +4857,17 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_round_trip_IEventElement_from_BasicEventElement()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
@@ -5732,7 +4877,7 @@ namespace AasCore.Aas3_0_RC02.Tests
             var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
                 anotherInstance);
 
-            AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+            Aas.Tests.CommonJson.CheckJsonNodesEqual(
                 jsonObject,
                 anotherJsonObject,
                 out Aas.Reporting.Error? error);

--- a/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs
@@ -6,7 +6,7 @@
 using System.Linq;  // can't alias
 using NUnit.Framework;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs
@@ -6,10 +6,10 @@
 using Directory = System.IO.Directory;
 using Nodes = System.Text.Json.Nodes;
 using Path = System.IO.Path;
-using Aas = AasCore.Aas3_0_RC02;
 
 using NUnit.Framework;  // can't alias
-using System.Linq;  // can't alias
+
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -19,10 +19,10 @@ namespace AasCore.Aas3_0_RC02.Tests
             object value,
             string expectedPath)
         {
-            Nodes.JsonNode got = AasCore.Aas3_0_RC02.Tests.CommonJson.ToJson(
+            Nodes.JsonNode got = Aas.Tests.CommonJson.ToJson(
                 value);
 
-            if (AasCore.Aas3_0_RC02.Tests.Common.RecordMode)
+            if (Aas.Tests.Common.RecordMode)
             {
                 string? parent = Path.GetDirectoryName(expectedPath);
                 if (parent != null)
@@ -44,10 +44,10 @@ namespace AasCore.Aas3_0_RC02.Tests
                         $"The file with the recorded value does not exist: {expectedPath}");
                 }
 
-                Nodes.JsonNode expected = AasCore.Aas3_0_RC02.Tests.CommonJson.ReadFromFile(
+                Nodes.JsonNode expected = Aas.Tests.CommonJson.ReadFromFile(
                     expectedPath);
 
-                AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+                Aas.Tests.CommonJson.CheckJsonNodesEqual(
                     expected, got, out Aas.Reporting.Error? error);
 
                 if (error != null)
@@ -66,40 +66,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Extension_ValueTypeOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Extension",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Extension)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Extension)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Extension could be found")
-            );
-
-            var theExtension = (instance as Aas.Extension)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Extension " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Extension>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theExtension.ValueTypeOrDefault())
+                instance.ValueTypeOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Extension",
                     "ValueTypeOrDefault.non-default.json"));
@@ -109,40 +96,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Extension_ValueTypeOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Extension",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Extension)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Extension)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Extension could be found")
-            );
-
-            var theExtension = (instance as Aas.Extension)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Extension " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Extension>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theExtension.ValueTypeOrDefault())
+                instance.ValueTypeOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Extension",
                     "ValueTypeOrDefault.default.json"));
@@ -152,40 +126,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Qualifier_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Qualifier",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Qualifier)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Qualifier)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Qualifier could be found")
-            );
-
-            var theQualifier = (instance as Aas.Qualifier)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Qualifier " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Qualifier>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theQualifier.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Qualifier",
                     "KindOrDefault.non-default.json"));
@@ -195,40 +156,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Qualifier_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Qualifier",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Qualifier)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Qualifier)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Qualifier could be found")
-            );
-
-            var theQualifier = (instance as Aas.Qualifier)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Qualifier " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Qualifier>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theQualifier.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Qualifier",
                     "KindOrDefault.default.json"));
@@ -238,40 +186,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Submodel_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
-
-            var theSubmodel = (instance as Aas.Submodel)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Submodel " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theSubmodel.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Submodel",
                     "KindOrDefault.non-default.json"));
@@ -281,40 +216,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Submodel_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Submodel)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Submodel)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Submodel could be found")
-            );
-
-            var theSubmodel = (instance as Aas.Submodel)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Submodel " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theSubmodel.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Submodel",
                     "KindOrDefault.default.json"));
@@ -324,40 +246,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_RelationshipElement_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
-
-            var theRelationshipElement = (instance as Aas.RelationshipElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of RelationshipElement " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theRelationshipElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "RelationshipElement",
                     "KindOrDefault.non-default.json"));
@@ -367,40 +276,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_RelationshipElement_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is RelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of RelationshipElement could be found")
-            );
-
-            var theRelationshipElement = (instance as Aas.RelationshipElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of RelationshipElement " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theRelationshipElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "RelationshipElement",
                     "KindOrDefault.default.json"));
@@ -410,40 +306,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SubmodelElementList_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
-
-            var theSubmodelElementList = (instance as Aas.SubmodelElementList)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of SubmodelElementList " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theSubmodelElementList.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "SubmodelElementList",
                     "KindOrDefault.non-default.json"));
@@ -453,40 +336,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SubmodelElementList_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
-
-            var theSubmodelElementList = (instance as Aas.SubmodelElementList)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of SubmodelElementList " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theSubmodelElementList.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "SubmodelElementList",
                     "KindOrDefault.default.json"));
@@ -496,37 +366,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SubmodelElementList_OrderRelevantOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
-            var theSubmodelElementList = (instance as Aas.SubmodelElementList)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of SubmodelElementList " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theSubmodelElementList.OrderRelevantOrDefault();
+            var value = instance.OrderRelevantOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "SubmodelElementList",
                     "OrderRelevantOrDefault.non-default.json"));
@@ -536,37 +393,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SubmodelElementList_OrderRelevantOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementList)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
-            var theSubmodelElementList = (instance as Aas.SubmodelElementList)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of SubmodelElementList " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theSubmodelElementList.OrderRelevantOrDefault();
+            var value = instance.OrderRelevantOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "SubmodelElementList",
                     "OrderRelevantOrDefault.default.json"));
@@ -576,40 +420,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SubmodelElementCollection_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
-
-            var theSubmodelElementCollection = (instance as Aas.SubmodelElementCollection)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of SubmodelElementCollection " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theSubmodelElementCollection.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "SubmodelElementCollection",
                     "KindOrDefault.non-default.json"));
@@ -619,40 +450,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_SubmodelElementCollection_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is SubmodelElementCollection)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of SubmodelElementCollection could be found")
-            );
-
-            var theSubmodelElementCollection = (instance as Aas.SubmodelElementCollection)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of SubmodelElementCollection " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theSubmodelElementCollection.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "SubmodelElementCollection",
                     "KindOrDefault.default.json"));
@@ -662,40 +480,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Property_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
-
-            var theProperty = (instance as Aas.Property)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Property " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theProperty.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Property",
                     "KindOrDefault.non-default.json"));
@@ -705,40 +510,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Property_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
-
-            var theProperty = (instance as Aas.Property)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Property " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theProperty.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Property",
                     "KindOrDefault.default.json"));
@@ -748,37 +540,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Property_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
-            var theProperty = (instance as Aas.Property)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Property " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theProperty.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Property",
                     "CategoryOrDefault.non-default.json"));
@@ -788,37 +567,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Property_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Property)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Property)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
-            var theProperty = (instance as Aas.Property)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Property " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theProperty.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Property",
                     "CategoryOrDefault.default.json"));
@@ -828,40 +594,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_MultiLanguageProperty_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
-
-            var theMultiLanguageProperty = (instance as Aas.MultiLanguageProperty)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of MultiLanguageProperty " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theMultiLanguageProperty.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "MultiLanguageProperty",
                     "KindOrDefault.non-default.json"));
@@ -871,40 +624,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_MultiLanguageProperty_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
-
-            var theMultiLanguageProperty = (instance as Aas.MultiLanguageProperty)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of MultiLanguageProperty " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theMultiLanguageProperty.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "MultiLanguageProperty",
                     "KindOrDefault.default.json"));
@@ -914,37 +654,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_MultiLanguageProperty_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
-            var theMultiLanguageProperty = (instance as Aas.MultiLanguageProperty)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of MultiLanguageProperty " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theMultiLanguageProperty.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "MultiLanguageProperty",
                     "CategoryOrDefault.non-default.json"));
@@ -954,37 +681,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_MultiLanguageProperty_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is MultiLanguageProperty)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
-            var theMultiLanguageProperty = (instance as Aas.MultiLanguageProperty)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of MultiLanguageProperty " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theMultiLanguageProperty.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "MultiLanguageProperty",
                     "CategoryOrDefault.default.json"));
@@ -994,40 +708,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Range_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
-
-            var theRange = (instance as Aas.Range)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Range " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theRange.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Range",
                     "KindOrDefault.non-default.json"));
@@ -1037,40 +738,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Range_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
-
-            var theRange = (instance as Aas.Range)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Range " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theRange.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Range",
                     "KindOrDefault.default.json"));
@@ -1080,37 +768,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Range_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
-            var theRange = (instance as Aas.Range)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Range " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theRange.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Range",
                     "CategoryOrDefault.non-default.json"));
@@ -1120,37 +795,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Range_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Range)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Range)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
-            var theRange = (instance as Aas.Range)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Range " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theRange.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Range",
                     "CategoryOrDefault.default.json"));
@@ -1160,40 +822,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ReferenceElement_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
-
-            var theReferenceElement = (instance as Aas.ReferenceElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of ReferenceElement " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theReferenceElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "ReferenceElement",
                     "KindOrDefault.non-default.json"));
@@ -1203,40 +852,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ReferenceElement_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
-
-            var theReferenceElement = (instance as Aas.ReferenceElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of ReferenceElement " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theReferenceElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "ReferenceElement",
                     "KindOrDefault.default.json"));
@@ -1246,37 +882,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ReferenceElement_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
-            var theReferenceElement = (instance as Aas.ReferenceElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of ReferenceElement " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theReferenceElement.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "ReferenceElement",
                     "CategoryOrDefault.non-default.json"));
@@ -1286,37 +909,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ReferenceElement_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ReferenceElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
-            var theReferenceElement = (instance as Aas.ReferenceElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of ReferenceElement " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theReferenceElement.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "ReferenceElement",
                     "CategoryOrDefault.default.json"));
@@ -1326,40 +936,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Blob_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
-
-            var theBlob = (instance as Aas.Blob)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Blob " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theBlob.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Blob",
                     "KindOrDefault.non-default.json"));
@@ -1369,40 +966,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Blob_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
-
-            var theBlob = (instance as Aas.Blob)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Blob " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theBlob.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Blob",
                     "KindOrDefault.default.json"));
@@ -1412,37 +996,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Blob_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
-            var theBlob = (instance as Aas.Blob)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Blob " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theBlob.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Blob",
                     "CategoryOrDefault.non-default.json"));
@@ -1452,37 +1023,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Blob_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Blob)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Blob)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
-            var theBlob = (instance as Aas.Blob)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Blob " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theBlob.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Blob",
                     "CategoryOrDefault.default.json"));
@@ -1492,40 +1050,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_File_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
-
-            var theFile = (instance as Aas.File)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of File " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theFile.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "File",
                     "KindOrDefault.non-default.json"));
@@ -1535,40 +1080,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_File_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
-
-            var theFile = (instance as Aas.File)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of File " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theFile.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "File",
                     "KindOrDefault.default.json"));
@@ -1578,37 +1110,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_File_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
-            var theFile = (instance as Aas.File)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of File " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theFile.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "File",
                     "CategoryOrDefault.non-default.json"));
@@ -1618,37 +1137,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_File_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is File)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is File)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
-            var theFile = (instance as Aas.File)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of File " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theFile.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "File",
                     "CategoryOrDefault.default.json"));
@@ -1658,40 +1164,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_AnnotatedRelationshipElement_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
-
-            var theAnnotatedRelationshipElement = (instance as Aas.AnnotatedRelationshipElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of AnnotatedRelationshipElement " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theAnnotatedRelationshipElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "AnnotatedRelationshipElement",
                     "KindOrDefault.non-default.json"));
@@ -1701,40 +1194,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_AnnotatedRelationshipElement_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is AnnotatedRelationshipElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of AnnotatedRelationshipElement could be found")
-            );
-
-            var theAnnotatedRelationshipElement = (instance as Aas.AnnotatedRelationshipElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of AnnotatedRelationshipElement " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theAnnotatedRelationshipElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "AnnotatedRelationshipElement",
                     "KindOrDefault.default.json"));
@@ -1744,40 +1224,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Entity_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
-
-            var theEntity = (instance as Aas.Entity)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Entity " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theEntity.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Entity",
                     "KindOrDefault.non-default.json"));
@@ -1787,40 +1254,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Entity_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Entity)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Entity)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Entity could be found")
-            );
-
-            var theEntity = (instance as Aas.Entity)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Entity " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theEntity.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Entity",
                     "KindOrDefault.default.json"));
@@ -1830,40 +1284,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_BasicEventElement_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
-
-            var theBasicEventElement = (instance as Aas.BasicEventElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of BasicEventElement " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theBasicEventElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "BasicEventElement",
                     "KindOrDefault.non-default.json"));
@@ -1873,40 +1314,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_BasicEventElement_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is BasicEventElement)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of BasicEventElement could be found")
-            );
-
-            var theBasicEventElement = (instance as Aas.BasicEventElement)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of BasicEventElement " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theBasicEventElement.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "BasicEventElement",
                     "KindOrDefault.default.json"));
@@ -1916,40 +1344,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Operation_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
-
-            var theOperation = (instance as Aas.Operation)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Operation " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theOperation.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Operation",
                     "KindOrDefault.non-default.json"));
@@ -1959,40 +1374,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Operation_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Operation)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Operation)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Operation could be found")
-            );
-
-            var theOperation = (instance as Aas.Operation)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Operation " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theOperation.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Operation",
                     "KindOrDefault.default.json"));
@@ -2002,40 +1404,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Capability_KindOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
-
-            var theCapability = (instance as Aas.Capability)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Capability " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theCapability.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Capability",
                     "KindOrDefault.non-default.json"));
@@ -2045,40 +1434,27 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_Capability_KindOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is Capability)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is Capability)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of Capability could be found")
-            );
-
-            var theCapability = (instance as Aas.Capability)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of Capability " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             string value = Aas.Stringification.ToString(
-                theCapability.KindOrDefault())
+                instance.KindOrDefault())
                     ?? throw new System.InvalidOperationException(
                         "Failed to stringify the enum");
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "Capability",
                     "KindOrDefault.default.json"));
@@ -2088,37 +1464,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ConceptDescription_CategoryOrDefault_non_default()
         {
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
-            var theConceptDescription = (instance as Aas.ConceptDescription)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of ConceptDescription " +
-                    $"in {pathToCompleteExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theConceptDescription.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "ConceptDescription",
                     "CategoryOrDefault.non-default.json"));
@@ -2128,37 +1491,24 @@ namespace AasCore.Aas3_0_RC02.Tests
         public void Test_ConceptDescription_CategoryOrDefault_default()
         {
             string pathToMinimalExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "minimal.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToMinimalExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                ? container
-                : container
-                    .Descend()
-                    .First(something => something is ConceptDescription)
-                        ?? throw new System.InvalidOperationException(
-                            "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
-            var theConceptDescription = (instance as Aas.ConceptDescription)
-                ?? throw new System.InvalidOperationException(
-                    "Expected an instance of ConceptDescription " +
-                    $"in {pathToMinimalExample}, " +
-                    $"but got a {instance.GetType()}");
-
-            var value = theConceptDescription.CategoryOrDefault();
+            var value = instance.CategoryOrDefault();
 
             CompareOrRerecordValue(
                 value,
                 Path.Combine(
-                    AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                    Aas.Tests.Common.OurTestResourceDir,
                     "XOrDefault",
                     "ConceptDescription",
                     "CategoryOrDefault.default.json"));

--- a/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfInterfaces.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfInterfaces.cs
@@ -6,9 +6,8 @@
 using Path = System.IO.Path;
 
 using NUnit.Framework;  // can't alias
-using System.Linq; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -20,24 +19,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -52,10 +44,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -70,7 +60,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -86,8 +76,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -104,24 +94,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -136,10 +119,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -154,7 +135,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -170,8 +151,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -188,24 +169,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -220,10 +194,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -238,7 +210,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -254,8 +226,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -272,24 +244,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -304,10 +269,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -322,7 +285,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -338,8 +301,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -356,24 +319,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -388,10 +344,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -406,7 +360,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -422,8 +376,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -440,24 +394,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -472,10 +419,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -490,7 +435,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -506,8 +451,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -524,24 +469,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -556,10 +494,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -574,7 +510,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -590,8 +526,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -608,24 +544,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -640,10 +569,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -658,7 +585,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -674,8 +601,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -692,24 +619,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -724,10 +644,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -742,7 +660,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -758,8 +676,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -776,24 +694,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -808,10 +719,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -826,7 +735,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -842,8 +751,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -860,24 +769,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -892,10 +794,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -910,7 +810,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -926,8 +826,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -944,24 +844,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -976,10 +869,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -994,7 +885,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1010,8 +901,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1028,24 +919,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1060,10 +944,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1078,7 +960,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1094,8 +976,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1112,24 +994,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1144,10 +1019,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1162,7 +1035,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1178,8 +1051,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1196,24 +1069,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1228,10 +1094,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHassemantics = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1246,7 +1110,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHassemantics = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasSemanticsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1262,8 +1126,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHassemantics,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1280,24 +1144,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1312,10 +1169,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1330,7 +1185,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1346,8 +1201,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1364,24 +1219,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1396,10 +1244,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1414,7 +1260,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1430,8 +1276,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1448,24 +1294,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AssetAdministrationShell)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1480,10 +1319,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.AssetAdministrationShell)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1498,7 +1335,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1514,8 +1351,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1532,24 +1369,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1564,10 +1394,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1582,7 +1410,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1598,8 +1426,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1616,24 +1444,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1648,10 +1469,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1666,7 +1485,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1682,8 +1501,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1700,24 +1519,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1732,10 +1544,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1750,7 +1560,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1766,8 +1576,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1784,24 +1594,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ConceptDescription)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1816,10 +1619,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.ConceptDescription)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1834,7 +1635,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1850,8 +1651,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1868,24 +1669,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1900,10 +1694,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1918,7 +1710,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -1934,8 +1726,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -1952,24 +1744,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -1984,10 +1769,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2002,7 +1785,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2018,8 +1801,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2036,24 +1819,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2068,10 +1844,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2086,7 +1860,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2102,8 +1876,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2120,24 +1894,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2152,10 +1919,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2170,7 +1935,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2186,8 +1951,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2204,24 +1969,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2236,10 +1994,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2254,7 +2010,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2270,8 +2026,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2288,24 +2044,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2320,10 +2069,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2338,7 +2085,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2354,8 +2101,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2372,24 +2119,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2404,10 +2144,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2422,7 +2160,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2438,8 +2176,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2456,24 +2194,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2488,10 +2219,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2506,7 +2235,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2522,8 +2251,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2540,24 +2269,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2572,10 +2294,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2590,7 +2310,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2606,8 +2326,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2624,24 +2344,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2656,10 +2369,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasextensions = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2674,7 +2385,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasextensions = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasExtensionsFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2690,8 +2401,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasextensions,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2708,24 +2419,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2740,10 +2444,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2758,7 +2460,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2774,8 +2476,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2792,24 +2494,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2824,10 +2519,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2842,7 +2535,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2858,8 +2551,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2876,24 +2569,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AssetAdministrationShell)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2908,10 +2594,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.AssetAdministrationShell)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2926,7 +2610,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -2942,8 +2626,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -2960,24 +2644,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -2992,10 +2669,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3010,7 +2685,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3026,8 +2701,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3044,24 +2719,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3076,10 +2744,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3094,7 +2760,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3110,8 +2776,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3128,24 +2794,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3160,10 +2819,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3178,7 +2835,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3194,8 +2851,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3212,24 +2869,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ConceptDescription)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3244,10 +2894,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.ConceptDescription)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3262,7 +2910,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3278,8 +2926,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3296,24 +2944,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3328,10 +2969,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3346,7 +2985,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3362,8 +3001,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3380,24 +3019,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3412,10 +3044,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3430,7 +3060,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3446,8 +3076,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3464,24 +3094,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3496,10 +3119,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3514,7 +3135,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3530,8 +3151,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3548,24 +3169,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3580,10 +3194,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3598,7 +3210,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3614,8 +3226,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3632,24 +3244,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3664,10 +3269,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3682,7 +3285,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3698,8 +3301,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3716,24 +3319,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3748,10 +3344,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3766,7 +3360,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3782,8 +3376,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3800,24 +3394,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3832,10 +3419,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3850,7 +3435,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3866,8 +3451,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3884,24 +3469,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -3916,10 +3494,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3934,7 +3510,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -3950,8 +3526,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -3968,24 +3544,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4000,10 +3569,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4018,7 +3585,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4034,8 +3601,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4052,24 +3619,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4084,10 +3644,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theReferable = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theReferable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4102,7 +3660,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherReferable = Aas.Xmlization.Deserialize.IReferableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IReferableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4118,8 +3676,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherReferable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4136,24 +3694,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AssetAdministrationShell)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4168,10 +3719,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theIdentifiable = (Aas.AssetAdministrationShell)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theIdentifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4186,7 +3735,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherIdentifiable = Aas.Xmlization.Deserialize.IIdentifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IIdentifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4202,8 +3751,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherIdentifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4220,24 +3769,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ConceptDescription)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4252,10 +3794,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theIdentifiable = (Aas.ConceptDescription)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theIdentifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4270,7 +3810,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherIdentifiable = Aas.Xmlization.Deserialize.IIdentifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IIdentifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4286,8 +3826,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherIdentifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4304,24 +3844,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4336,10 +3869,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theIdentifiable = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theIdentifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4354,7 +3885,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherIdentifiable = Aas.Xmlization.Deserialize.IIdentifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IIdentifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4370,8 +3901,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherIdentifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4388,24 +3919,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4420,10 +3944,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4438,7 +3960,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4454,8 +3976,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4472,24 +3994,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4504,10 +4019,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4522,7 +4035,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4538,8 +4051,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4556,24 +4069,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4588,10 +4094,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4606,7 +4110,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4622,8 +4126,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4640,24 +4144,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4672,10 +4169,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4690,7 +4185,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4706,8 +4201,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4724,24 +4219,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4756,10 +4244,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4774,7 +4260,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4790,8 +4276,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4808,24 +4294,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4840,10 +4319,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4858,7 +4335,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4874,8 +4351,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4892,24 +4369,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -4924,10 +4394,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4942,7 +4410,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -4958,8 +4426,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -4976,24 +4444,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5008,10 +4469,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5026,7 +4485,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5042,8 +4501,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5060,24 +4519,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5092,10 +4544,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5110,7 +4560,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5126,8 +4576,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5144,24 +4594,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5176,10 +4619,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5194,7 +4635,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5210,8 +4651,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5228,24 +4669,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5260,10 +4694,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5278,7 +4710,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5294,8 +4726,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5312,24 +4744,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5344,10 +4769,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5362,7 +4785,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5378,8 +4801,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5396,24 +4819,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5428,10 +4844,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5446,7 +4860,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5462,8 +4876,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5480,24 +4894,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5512,10 +4919,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5530,7 +4935,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5546,8 +4951,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5564,24 +4969,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5596,10 +4994,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHaskind = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHaskind,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5614,7 +5010,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHaskind = Aas.Xmlization.Deserialize.IHasKindFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasKindFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5630,8 +5026,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHaskind,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5648,24 +5044,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5680,10 +5069,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5698,7 +5085,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5714,8 +5101,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5732,24 +5119,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5764,10 +5144,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5782,7 +5160,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5798,8 +5176,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5816,24 +5194,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AssetAdministrationShell",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AssetAdministrationShell)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AssetAdministrationShell)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AssetAdministrationShell could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AssetAdministrationShell>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5848,10 +5219,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.AssetAdministrationShell)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5866,7 +5235,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5882,8 +5251,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5900,24 +5269,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -5932,10 +5294,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5950,7 +5310,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -5966,8 +5326,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -5984,24 +5344,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6016,10 +5369,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6034,7 +5385,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6050,8 +5401,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6068,24 +5419,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6100,10 +5444,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6118,7 +5460,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6134,8 +5476,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6152,24 +5494,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ConceptDescription",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ConceptDescription)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ConceptDescription)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ConceptDescription could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ConceptDescription>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6184,10 +5519,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.ConceptDescription)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6202,7 +5535,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6218,8 +5551,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6236,24 +5569,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6268,10 +5594,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6286,7 +5610,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6302,8 +5626,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6320,24 +5644,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6352,10 +5669,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6370,7 +5685,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6386,8 +5701,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6404,24 +5719,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6436,10 +5744,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6454,7 +5760,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6470,8 +5776,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6488,24 +5794,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6520,10 +5819,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6538,7 +5835,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6554,8 +5851,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6572,24 +5869,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6604,10 +5894,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6622,7 +5910,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6638,8 +5926,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6656,24 +5944,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6688,10 +5969,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6706,7 +5985,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6722,8 +6001,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6740,24 +6019,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6772,10 +6044,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6790,7 +6060,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6806,8 +6076,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6824,24 +6094,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6856,10 +6119,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6874,7 +6135,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6890,8 +6151,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6908,24 +6169,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -6940,10 +6194,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6958,7 +6210,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -6974,8 +6226,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -6992,24 +6244,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7024,10 +6269,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theHasdataspecification = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7042,7 +6285,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherHasdataspecification = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IHasDataSpecificationFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7058,8 +6301,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherHasdataspecification,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7076,24 +6319,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7108,10 +6344,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7126,7 +6360,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7142,8 +6376,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7160,24 +6394,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7192,10 +6419,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7210,7 +6435,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7226,8 +6451,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7244,24 +6469,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7276,10 +6494,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7294,7 +6510,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7310,8 +6526,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7328,24 +6544,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7360,10 +6569,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7378,7 +6585,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7394,8 +6601,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7412,24 +6619,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7444,10 +6644,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7462,7 +6660,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7478,8 +6676,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7496,24 +6694,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7528,10 +6719,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7546,7 +6735,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7562,8 +6751,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7580,24 +6769,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7612,10 +6794,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7630,7 +6810,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7646,8 +6826,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7664,24 +6844,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7696,10 +6869,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7714,7 +6885,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7730,8 +6901,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7748,24 +6919,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7780,10 +6944,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7798,7 +6960,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7814,8 +6976,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7832,24 +6994,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7864,10 +7019,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7882,7 +7035,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7898,8 +7051,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7916,24 +7069,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -7948,10 +7094,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -7966,7 +7110,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -7982,8 +7126,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8000,24 +7144,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8032,10 +7169,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8050,7 +7185,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8066,8 +7201,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8084,24 +7219,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Submodel",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Submodel)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Submodel)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Submodel could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Submodel>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8116,10 +7244,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.Submodel)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8134,7 +7260,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8150,8 +7276,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8168,24 +7294,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8200,10 +7319,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8218,7 +7335,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8234,8 +7351,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8252,24 +7369,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8284,10 +7394,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theQualifiable = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8302,7 +7410,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherQualifiable = Aas.Xmlization.Deserialize.IQualifiableFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IQualifiableFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8318,8 +7426,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherQualifiable,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8336,24 +7444,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8368,10 +7469,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8386,7 +7485,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8402,8 +7501,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8420,24 +7519,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8452,10 +7544,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8470,7 +7560,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8486,8 +7576,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8504,24 +7594,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8536,10 +7619,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8554,7 +7635,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8570,8 +7651,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8588,24 +7669,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8620,10 +7694,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8638,7 +7710,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8654,8 +7726,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8672,24 +7744,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Capability",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Capability)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Capability)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Capability could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Capability>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8704,10 +7769,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.Capability)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8722,7 +7785,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8738,8 +7801,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8756,24 +7819,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Entity",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Entity)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Entity)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Entity could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Entity>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8788,10 +7844,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.Entity)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8806,7 +7860,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8822,8 +7876,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8840,24 +7894,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8872,10 +7919,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8890,7 +7935,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8906,8 +7951,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8924,24 +7969,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -8956,10 +7994,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -8974,7 +8010,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -8990,8 +8026,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9008,24 +8044,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Operation",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Operation)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Operation)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Operation could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Operation>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9040,10 +8069,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.Operation)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9058,7 +8085,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9074,8 +8101,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9092,24 +8119,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9124,10 +8144,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9142,7 +8160,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9158,8 +8176,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9176,24 +8194,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9208,10 +8219,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9226,7 +8235,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9242,8 +8251,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9260,24 +8269,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9292,10 +8294,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9310,7 +8310,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9326,8 +8326,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9344,24 +8344,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementCollection",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementCollection)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementCollection)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementCollection could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementCollection>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9376,10 +8369,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.SubmodelElementCollection)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9394,7 +8385,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9410,8 +8401,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9428,24 +8419,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "SubmodelElementList",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is SubmodelElementList)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is SubmodelElementList)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of SubmodelElementList could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.SubmodelElementList>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9460,10 +8444,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theSubmodelelement = (Aas.SubmodelElementList)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9478,7 +8460,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherSubmodelelement = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.ISubmodelElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9494,8 +8476,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherSubmodelelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9512,24 +8494,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "AnnotatedRelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is AnnotatedRelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is AnnotatedRelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of AnnotatedRelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.AnnotatedRelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9544,10 +8519,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theRelationshipelement = (Aas.AnnotatedRelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theRelationshipelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9562,7 +8535,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherRelationshipelement = Aas.Xmlization.Deserialize.IRelationshipElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IRelationshipElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9578,8 +8551,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherRelationshipelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9596,24 +8569,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "RelationshipElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is RelationshipElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is RelationshipElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of RelationshipElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.RelationshipElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9628,10 +8594,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theRelationshipelement = (Aas.RelationshipElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theRelationshipelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9646,7 +8610,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherRelationshipelement = Aas.Xmlization.Deserialize.IRelationshipElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IRelationshipElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9662,8 +8626,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherRelationshipelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9680,24 +8644,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Blob",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Blob)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Blob)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Blob could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Blob>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9712,10 +8669,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theDataelement = (Aas.Blob)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theDataelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9730,7 +8685,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherDataelement = Aas.Xmlization.Deserialize.IDataElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IDataElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9746,8 +8701,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherDataelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9764,24 +8719,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "File",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is File)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is File)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of File could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.File>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9796,10 +8744,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theDataelement = (Aas.File)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theDataelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9814,7 +8760,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherDataelement = Aas.Xmlization.Deserialize.IDataElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IDataElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9830,8 +8776,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherDataelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9848,24 +8794,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "MultiLanguageProperty",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is MultiLanguageProperty)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is MultiLanguageProperty)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of MultiLanguageProperty could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.MultiLanguageProperty>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9880,10 +8819,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theDataelement = (Aas.MultiLanguageProperty)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theDataelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9898,7 +8835,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherDataelement = Aas.Xmlization.Deserialize.IDataElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IDataElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9914,8 +8851,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherDataelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9932,24 +8869,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Property",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Property)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Property)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Property could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Property>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -9964,10 +8894,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theDataelement = (Aas.Property)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theDataelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -9982,7 +8910,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherDataelement = Aas.Xmlization.Deserialize.IDataElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IDataElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -9998,8 +8926,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherDataelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -10016,24 +8944,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "Range",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is Range)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is Range)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of Range could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.Range>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -10048,10 +8969,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theDataelement = (Aas.Range)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theDataelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -10066,7 +8985,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherDataelement = Aas.Xmlization.Deserialize.IDataElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IDataElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -10082,8 +9001,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherDataelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -10100,24 +9019,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "ReferenceElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is ReferenceElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is ReferenceElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of ReferenceElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.ReferenceElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -10132,10 +9044,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theDataelement = (Aas.ReferenceElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theDataelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -10150,7 +9060,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherDataelement = Aas.Xmlization.Deserialize.IDataElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IDataElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -10166,8 +9076,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherDataelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -10184,24 +9094,17 @@ namespace AasCore.Aas3_0_RC02.Tests
             // We load from JSON here just to jump-start the round trip.
             // The round-trip goes then over XML.
             string pathToCompleteExample = Path.Combine(
-                AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+                Aas.Tests.Common.OurTestResourceDir,
                 "Json",
                 "Expected",
                 "BasicEventElement",
                 "complete.json");
 
-            var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+            var container = Aas.Tests.CommonJson.LoadInstance(
                 pathToCompleteExample);
 
-            var instance = (
-                (container is BasicEventElement)
-                    ? container
-                    : container
-                          .Descend()
-                          .First(something => something is BasicEventElement)
-                      ?? throw new System.InvalidOperationException(
-                          "No instance of BasicEventElement could be found")
-            );
+            var instance = Aas.Tests.Common.MustFind<Aas.BasicEventElement>(
+                container);
 
             // The round-trip starts here.
             var outputBuilder = new System.Text.StringBuilder();
@@ -10216,10 +9119,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                var theEventelement = (Aas.BasicEventElement)instance;
-
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    theEventelement,
+                Aas.Xmlization.Serialize.To(
+                    instance,
                     xmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");
@@ -10234,7 +9135,7 @@ namespace AasCore.Aas3_0_RC02.Tests
                 outputReader,
                 new System.Xml.XmlReaderSettings());
 
-            var anotherEventelement = Aas.Xmlization.Deserialize.IEventElementFrom(
+            var anotherInstance = Aas.Xmlization.Deserialize.IEventElementFrom(
                 xmlReader,
                 "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -10250,8 +9151,8 @@ namespace AasCore.Aas3_0_RC02.Tests
                         OmitXmlDeclaration = true
                     });
 
-                AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-                    anotherEventelement,
+                Aas.Xmlization.Serialize.To(
+                    anotherInstance,
                     anotherXmlWriter,
                     "aas",
                     "https://www.admin-shell.io/aas/3/0/RC02");

--- a/testgen/generate_all.py
+++ b/testgen/generate_all.py
@@ -1,0 +1,40 @@
+"""Generate all the code using testgen."""
+
+import os
+import pathlib
+import shlex
+import subprocess
+import sys
+
+
+def main() -> int:
+    """Execute the main routine."""
+    this_path = pathlib.Path(os.path.realpath(__file__))
+    testgen_dir = this_path.parent
+
+    for script_pth in sorted(testgen_dir.glob("generate_*.py")):
+        if script_pth == this_path:
+            continue
+
+        cmd = [
+            sys.executable,
+            str(script_pth)
+        ]
+
+        cmd_str = " ".join(shlex.quote(part) for part in cmd)
+
+        print(f"Executing: {script_pth.relative_to(testgen_dir)}")
+        return_code = subprocess.call(cmd, cwd=str(script_pth.parent))
+        if return_code != 0:
+
+            print(
+                f"Failed with return code {return_code}: {cmd_str}",
+                file=sys.stderr
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testgen/generate_test_for_descend_once.py
+++ b/testgen/generate_test_for_descend_once.py
@@ -13,8 +13,6 @@ import aas_core_codegen.csharp.naming
 import aas_core_codegen.naming
 import aas_core_codegen.parse
 import aas_core_codegen.run
-import aas_core_meta.v3rc2
-
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Stripped
 from aas_core_codegen.csharp import (
@@ -65,7 +63,7 @@ private static void CompareOrRerecordTrace(
 
     string got = writer.ToString();
 
-    if (AasCore.Aas3_0_RC02.Tests.Common.RecordMode)
+    if (Aas.Tests.Common.RecordMode)
     {
         string? parent = Path.GetDirectoryName(expectedPath);
         if (parent != null)
@@ -116,29 +114,22 @@ private static void CompareOrRerecordTrace(
 public void Test_{cls_name_csharp}()
 {{
     string pathToCompleteExample = Path.Combine(
-        AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+        Aas.Tests.Common.OurTestResourceDir,
         "Json",
         "Expected",
         {csharp_common.string_literal(cls_name_json)},
         "complete.json");
     
-    var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+    var container = Aas.Tests.CommonJson.LoadInstance(
         pathToCompleteExample);
 
-    var instance = (
-        (container is {cls_name_csharp})
-        ? container
-        : container
-            .Descend()
-            .First(something => something is {cls_name_csharp})
-                ?? throw new System.InvalidOperationException(
-                    "No instance of {cls_name_csharp} could be found") 
-    );
+    var instance = Aas.Tests.Common.MustFind<Aas.{cls_name_csharp}>(
+        container);
     
     CompareOrRerecordTrace(
         instance,
         Path.Combine(
-            AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+            Aas.Tests.Common.OurTestResourceDir,
             "DescendOnce",
             {csharp_common.string_literal(cls_name_json)},
             "complete.json.trace"));
@@ -157,8 +148,9 @@ public void Test_{cls_name_csharp}()
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
-using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
+
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_concrete_classes_outside_environment.py
+++ b/testgen/generate_test_for_jsonization_of_concrete_classes_outside_environment.py
@@ -51,25 +51,18 @@ def main() -> int:
 public void Test_round_trip_{cls_name_csharp}()
 {{
     string pathToCompleteExample = Path.Combine(
-        AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+        Aas.Tests.Common.OurTestResourceDir,
         "Json",
         "Expected",
         {csharp_common.string_literal(cls_name_json)},
         "complete.json");
     
-    var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+    var container = Aas.Tests.CommonJson.LoadInstance(
         pathToCompleteExample);
-
-    var instance = (
-        (container is {cls_name_csharp})
-        ? container
-        : container
-            .Descend()
-            .First(something => something is {cls_name_csharp})
-                ?? throw new System.InvalidOperationException(
-                    "No instance of {cls_name_csharp} could be found") 
-    );
     
+    var instance = Aas.Tests.Common.MustFind<Aas.{cls_name_csharp}>(
+        container);
+
     var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
     
     var anotherInstance = Aas.Jsonization.Deserialize.{cls_name_csharp}From(
@@ -78,7 +71,7 @@ public void Test_round_trip_{cls_name_csharp}()
     var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
         anotherInstance);
 
-    AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+    Aas.Tests.CommonJson.CheckJsonNodesEqual(
         jsonObject,
         anotherJsonObject,
         out Aas.Reporting.Error? error);
@@ -106,10 +99,9 @@ public void Test_round_trip_{cls_name_csharp}()
 
 using Path = System.IO.Path;
 
-using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_enums.py
+++ b/testgen/generate_test_for_jsonization_of_enums.py
@@ -81,7 +81,7 @@ using Nodes = System.Text.Json.Nodes;
 
 using NUnit.Framework;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_interfaces.py
+++ b/testgen/generate_test_for_jsonization_of_interfaces.py
@@ -61,25 +61,18 @@ def main() -> int:
 public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
 {{
     string pathToCompleteExample = Path.Combine(
-        AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+        Aas.Tests.Common.OurTestResourceDir,
         "Json",
         "Expected",
         {csharp_common.string_literal(cls_name_json)},
         "complete.json");
     
-    var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+    var container = Aas.Tests.CommonJson.LoadInstance(
         pathToCompleteExample);
 
-    var instance = (
-        (container is {cls_name_csharp})
-        ? container
-        : container
-            .Descend()
-            .First(something => something is {cls_name_csharp})
-                ?? throw new System.InvalidOperationException(
-                    "No instance of {cls_name_csharp} could be found") 
-    );
-    
+    var instance = Aas.Tests.Common.MustFind<Aas.{cls_name_csharp}>(
+        container);
+
     var jsonObject = Aas.Jsonization.Serialize.ToJsonObject(instance);
 
     var anotherInstance = Aas.Jsonization.Deserialize.{interface_name_csharp}From(
@@ -88,7 +81,7 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
     var anotherJsonObject = Aas.Jsonization.Serialize.ToJsonObject(
         anotherInstance);
             
-    AasCore.Aas3_0_RC02.Tests.CommonJson.CheckJsonNodesEqual(
+    Aas.Tests.CommonJson.CheckJsonNodesEqual(
         jsonObject,
         anotherJsonObject,
         out Aas.Reporting.Error? error);
@@ -117,9 +110,8 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
 using Path = System.IO.Path;
 
 using NUnit.Framework;  // can't alias
-using System.Linq; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_xmlization_of_interfaces.py
+++ b/testgen/generate_test_for_xmlization_of_interfaces.py
@@ -52,18 +52,6 @@ def main() -> int:
                 symbol.interface.name
             )
 
-            assert interface_name_csharp.startswith("I")
-            var_name = aas_core_codegen.csharp.naming.variable_name(
-                aas_core_codegen.common.Identifier(
-                    "the_" + interface_name_csharp[1:]
-                )
-            )
-            another_var_name = aas_core_codegen.csharp.naming.variable_name(
-                aas_core_codegen.common.Identifier(
-                    "another_" + interface_name_csharp[1:]
-                )
-            )
-
             cls_name_csharp = aas_core_codegen.csharp.naming.class_name(cls.name)
             cls_name_json = aas_core_codegen.naming.json_model_type(cls.name)
 
@@ -76,24 +64,17 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
     // We load from JSON here just to jump-start the round trip.
     // The round-trip goes then over XML.
     string pathToCompleteExample = Path.Combine(
-        AasCore.Aas3_0_RC02.Tests.Common.OurTestResourceDir,
+        Aas.Tests.Common.OurTestResourceDir,
         "Json",
         "Expected",
         "{cls_name_json}",
         "complete.json");
 
-    var container = AasCore.Aas3_0_RC02.Tests.CommonJson.LoadInstance(
+    var container = Aas.Tests.CommonJson.LoadInstance(
         pathToCompleteExample);
 
-    var instance = (
-        (container is {cls_name_csharp})
-            ? container
-            : container
-                  .Descend()
-                  .First(something => something is {cls_name_csharp})
-              ?? throw new System.InvalidOperationException(
-                  "No instance of {cls_name_csharp} could be found")
-    );
+    var instance = Aas.Tests.Common.MustFind<Aas.{cls_name_csharp}>(
+        container);
 
     // The round-trip starts here.
     var outputBuilder = new System.Text.StringBuilder();
@@ -108,10 +89,8 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
                 OmitXmlDeclaration = true
             }});
 
-        var {var_name} = (Aas.{cls_name_csharp})instance;
-
-        AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-            {var_name},
+        Aas.Xmlization.Serialize.To(
+            instance,
             xmlWriter,
             "aas",
             "https://www.admin-shell.io/aas/3/0/RC02");
@@ -126,7 +105,7 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
         outputReader,
         new System.Xml.XmlReaderSettings());
 
-    var {another_var_name} = Aas.Xmlization.Deserialize.{interface_name_csharp}From(
+    var anotherInstance = Aas.Xmlization.Deserialize.{interface_name_csharp}From(
         xmlReader,
         "https://www.admin-shell.io/aas/3/0/RC02");
 
@@ -142,8 +121,8 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
                 OmitXmlDeclaration = true
             }});
 
-        AasCore.Aas3_0_RC02.Xmlization.Serialize.To(
-            {another_var_name},
+        Aas.Xmlization.Serialize.To(
+            anotherInstance,
             anotherXmlWriter,
             "aas",
             "https://www.admin-shell.io/aas/3/0/RC02");
@@ -167,9 +146,8 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
 using Path = System.IO.Path;
 
 using NUnit.Framework;  // can't alias
-using System.Linq; // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_verification_of_enums.py
+++ b/testgen/generate_test_verification_of_enums.py
@@ -84,7 +84,7 @@ public void Test_{enum_name}_invalid()
 using System.Linq;  // can't alias
 using NUnit.Framework;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {


### PR DESCRIPTION
The test code became a hodge-podge of different styles. Notably, we used
aliasing of usings inconsistently and did not leverage all the helper
functions in ``Common`` as we could.

This patch tries to make the test code uniform.