### PR TITLE
Update to aas-core-codegen 9a0b74b

### DIFF
--- a/.idea/aas-core3.0rc02-csharp.iml
+++ b/.idea/aas-core3.0rc02-csharp.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -3,7 +3,9 @@
     <words>
       <w>atok</w>
       <w>braunisch</w>
+      <w>jsonization</w>
       <w>ristin</w>
+      <w>xmlization</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,81 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="hx-headers" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="9">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+            <item index="6" class="java.lang.String" itemvalue="def" />
+            <item index="7" class="java.lang.String" itemvalue="phase" />
+            <item index="8" class="java.lang.String" itemvalue="model" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="InstalledPackageInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="JsonStandardCompliance" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="icontract" />
+            <item index="1" class="java.lang.String" itemvalue="hypothesis" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E501" />
+          <option value="E741" />
+          <option value="E122" />
+          <option value="E131" />
+          <option value="E203" />
+          <option value="E261" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyProtectedMemberInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyShadowingBuiltinsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyStubPackagesAdvertiser" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <list>
+          <option value="docutils-stubs==0.0.22" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="bool.__await__" />
+          <option value="aas_core_csharp_codegen.parse.tree.Expression.name" />
+          <option value="django.db.models.base.Model._meta" />
+          <option value="django.db.models.base.Model.objects" />
+          <option value="know_thy_risk.models.Product.objects" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="ReferenceExistsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="UnusedInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/aas-core3.0rc02-csharp.iml" filepath="$PROJECT_DIR$/.idea/aas-core3.0rc02-csharp.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -30,7 +30,21 @@
     <select />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="9320e216-0e07-4101-8ce3-cd62bc1769d1" name="Default Changelist" comment="" />
+    <list default="true" id="9320e216-0e07-4101-8ce3-cd62bc1769d1" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/dictionaries/rist.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dictionaries/rist.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_common_jsonization.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_common_jsonization.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_descend_and_visitor_through.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_descend_and_visitor_through.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_descend_once.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_descend_once.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_get_X_or_default.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_get_X_or_default.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_enums.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_enums.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_interfaces.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_interfaces.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_over_X_or_empty.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_over_X_or_empty.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_xmlization_of_concrete_classes.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_xmlization_of_concrete_classes.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/testgen/requirements.txt" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/requirements.txt" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -68,7 +82,7 @@
       <recent name="C:\Users\rist\workspace\aas-core-works\aas-core3.0rc02-csharp\src" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.generate_test_for_over_X_or_empty">
+  <component name="RunManager" selected="Python.generate_all">
     <configuration name="generate_all" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="aas-core3.0rc02-csharp" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -176,8 +190,8 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Python.generate_test_for_over_X_or_empty" />
         <item itemvalue="Python.generate_all" />
+        <item itemvalue="Python.generate_test_for_over_X_or_empty" />
         <item itemvalue="Python.generate_test_for_jsonization_of_concrete_classes_outside_container" />
         <item itemvalue="Python.generate_test_for_xmlization_of_interfaces" />
         <item itemvalue="Python.generate_test_for_xmlization_of_concrete_classes_outside_environment" />

--- a/testgen/generate_common_jsonization.py
+++ b/testgen/generate_common_jsonization.py
@@ -34,25 +34,24 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    environment_cls = symbol_table.must_find(
+    environment_cls = symbol_table.must_find_concrete_class(
         aas_core_codegen.common.Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
         container_cls = testgen.common.determine_container_class(
-            cls=symbol, test_data_dir=test_data_dir,
+            cls=our_type, test_data_dir=test_data_dir,
             environment_cls=environment_cls)
         container_cls_csharp = aas_core_codegen.csharp.naming.class_name(
             container_cls.name
         )
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
-        cls_name_json = aas_core_codegen.naming.json_model_type(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
+        cls_name_json = aas_core_codegen.naming.json_model_type(our_type.name)
 
-        if container_cls is symbol:
+        if container_cls is our_type:
             deserialization_snippet = Stripped(
                 f"""\
 var instance = Aas.Jsonization.Deserialize.{cls_name_csharp}From(

--- a/testgen/generate_test_for_descend_and_visitor_through.py
+++ b/testgen/generate_test_for_descend_and_visitor_through.py
@@ -151,12 +151,12 @@ private static void CompareOrRerecordTrace(
         )
     )
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
-        cls_name_json = aas_core_codegen.naming.json_model_type(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
+        cls_name_json = aas_core_codegen.naming.json_model_type(our_type.name)
 
         blocks.append(
             Stripped(

--- a/testgen/generate_test_for_descend_once.py
+++ b/testgen/generate_test_for_descend_once.py
@@ -20,17 +20,14 @@ from aas_core_codegen.csharp import (
 )
 
 import testgen.common
-from testgen.common import load_symbol_table
 
 
 def main() -> int:
     """Execute the main routine."""
-    symbol_table = load_symbol_table()
+    symbol_table = testgen.common.load_symbol_table()
 
     this_path = pathlib.Path(os.path.realpath(__file__))
     repo_root = this_path.parent.parent
-
-    test_data_dir = repo_root / "test_data"
 
     # noinspection PyListCreation
     blocks = []  # type: List[str]
@@ -100,16 +97,12 @@ private static void CompareOrRerecordTrace(
         )
     )
 
-    environment_cls = symbol_table.must_find(
-        aas_core_codegen.common.Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
-
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
-        cls_name_json = aas_core_codegen.naming.json_model_type(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
+        cls_name_json = aas_core_codegen.naming.json_model_type(our_type.name)
 
         blocks.append(
             Stripped(

--- a/testgen/generate_test_for_get_X_or_default.py
+++ b/testgen/generate_test_for_get_X_or_default.py
@@ -81,15 +81,15 @@ private static void CompareOrRerecordValue(
         )
     )
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
-        cls_name_json = aas_core_codegen.naming.json_model_type(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
+        cls_name_json = aas_core_codegen.naming.json_model_type(our_type.name)
 
         x_or_default_methods = []  # type: List[intermediate.Method]
-        for method in symbol.methods:
+        for method in our_type.methods:
             if method.name.endswith("_or_default"):
                 x_or_default_methods.append(method)
 
@@ -99,14 +99,14 @@ private static void CompareOrRerecordValue(
             result_enum = None  # type: Optional[intermediate.Enumeration]
             assert method.returns is not None, (
                 f"Expected all X_or_default to return something, "
-                f"but got None for {symbol}.{method.name}"
+                f"but got None for {our_type}.{method.name}"
             )
 
             if (
                     isinstance(method.returns, intermediate.OurTypeAnnotation)
-                    and isinstance(method.returns.symbol, intermediate.Enumeration)
+                    and isinstance(method.returns.our_type, intermediate.Enumeration)
             ):
-                result_enum = method.returns.symbol
+                result_enum = method.returns.our_type
 
             if result_enum is None:
                 value_assignment_snippet = Stripped(

--- a/testgen/generate_test_for_jsonization_of_concrete_classes.py
+++ b/testgen/generate_test_for_jsonization_of_concrete_classes.py
@@ -410,25 +410,24 @@ private static void AssertEqualsExpectedOrRerecordDeserializationException(
         )
     )
 
-    environment_cls = symbol_table.must_find(
+    environment_cls = symbol_table.must_find_concrete_class(
         aas_core_codegen.common.Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
         container_cls = testgen.common.determine_container_class(
-            cls=symbol, test_data_dir=test_data_dir,
+            cls=our_type, test_data_dir=test_data_dir,
             environment_cls=environment_cls)
         container_cls_csharp = aas_core_codegen.csharp.naming.class_name(
             container_cls.name
         )
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
-        cls_name_json = aas_core_codegen.naming.json_model_type(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
+        cls_name_json = aas_core_codegen.naming.json_model_type(our_type.name)
 
-        if container_cls is symbol:
+        if container_cls is our_type:
             blocks.extend(
                 _generate_for_self_contained(
                     cls_name_csharp=cls_name_csharp,

--- a/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py
+++ b/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py
@@ -31,25 +31,24 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    environment_cls = symbol_table.must_find(
+    environment_cls = symbol_table.must_find_concrete_class(
         aas_core_codegen.common.Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
         container_cls = testgen.common.determine_container_class(
-            cls=symbol, test_data_dir=test_data_dir,
+            cls=our_type, test_data_dir=test_data_dir,
             environment_cls=environment_cls)
 
-        if container_cls is symbol:
+        if container_cls is our_type:
             # NOTE (mristin, 2022-06-27):
             # These classes are tested already in TestJsonizationOfConcreteClasses.
             # We only need to test for class instances contained in a container.
             continue
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
 
         blocks.append(
             Stripped(

--- a/testgen/generate_test_for_jsonization_of_enums.py
+++ b/testgen/generate_test_for_jsonization_of_enums.py
@@ -14,8 +14,6 @@ import aas_core_codegen.csharp.naming
 import aas_core_codegen.naming
 import aas_core_codegen.parse
 import aas_core_codegen.run
-import aas_core_meta.v3rc2
-
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Stripped
 from aas_core_codegen.csharp import (
@@ -32,17 +30,17 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.Enumeration):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.Enumeration):
             continue
 
-        enum_name = aas_core_codegen.csharp.naming.enum_name(symbol.name)
+        enum_name = aas_core_codegen.csharp.naming.enum_name(our_type.name)
 
-        assert len(symbol.literals) > 0, (
-            f"Unexpected enumeration without literals: {symbol.name}"
+        assert len(our_type.literals) > 0, (
+            f"Unexpected enumeration without literals: {our_type.name}"
         )
 
-        literal_value = symbol.literals[0].value
+        literal_value = our_type.literals[0].value
         literal_value_json_str = json.dumps(literal_value)
 
         blocks.append(

--- a/testgen/generate_test_for_jsonization_of_interfaces.py
+++ b/testgen/generate_test_for_jsonization_of_interfaces.py
@@ -13,13 +13,8 @@ import aas_core_codegen.csharp.naming
 import aas_core_codegen.naming
 import aas_core_codegen.parse
 import aas_core_codegen.run
-import aas_core_meta.v3rc2
-
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Stripped
-from aas_core_codegen.csharp import (
-    common as csharp_common
-)
 
 from testgen.common import load_symbol_table
 
@@ -31,28 +26,27 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.Class):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.Class):
             continue
 
-        if symbol.interface is None or len(symbol.interface.implementers) == 0:
+        if our_type.interface is None or len(our_type.interface.implementers) == 0:
             continue
 
-        if symbol.name == aas_core_codegen.common.Identifier("Event_payload"):
+        if our_type.name == aas_core_codegen.common.Identifier("Event_payload"):
             # NOTE (mristin, 2022-06-21):
             # Event payload is a dangling class and can not be reached from
             # the environment. Hence, we skip it.
             continue
 
-        for cls in symbol.interface.implementers:
+        for cls in our_type.interface.implementers:
             if cls.serialization is None or not cls.serialization.with_model_type:
                 continue
 
             interface_name_csharp = aas_core_codegen.csharp.naming.interface_name(
-                symbol.interface.name
+                our_type.interface.name
             )
             cls_name_csharp = aas_core_codegen.csharp.naming.class_name(cls.name)
-            cls_name_json = aas_core_codegen.naming.json_model_type(cls.name)
 
             blocks.append(
                 Stripped(

--- a/testgen/generate_test_for_over_X_or_empty.py
+++ b/testgen/generate_test_for_over_X_or_empty.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import sys
 import textwrap
-from typing import List, Optional
+from typing import List
 
 import aas_core_codegen
 import aas_core_codegen.common
@@ -15,9 +15,6 @@ import aas_core_codegen.parse
 import aas_core_codegen.run
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Stripped
-from aas_core_codegen.csharp import (
-    common as csharp_common
-)
 
 from testgen.common import load_symbol_table
 
@@ -29,13 +26,13 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
 
-        for prop in symbol.properties:
+        for prop in our_type.properties:
             if (
                     isinstance(
                         prop.type_annotation, intermediate.OptionalTypeAnnotation)

--- a/testgen/generate_test_for_xmlization_of_concrete_classes.py
+++ b/testgen/generate_test_for_xmlization_of_concrete_classes.py
@@ -487,25 +487,24 @@ private static void AssertEqualsExpectedOrRerecordDeserializationException(
         )
     )
 
-    environment_cls = symbol_table.must_find(
+    environment_cls = symbol_table.must_find_concrete_class(
         aas_core_codegen.common.Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
         container_cls = testgen.common.determine_container_class(
-            cls=symbol, test_data_dir=test_data_dir,
+            cls=our_type, test_data_dir=test_data_dir,
             environment_cls=environment_cls)
         container_cls_csharp = aas_core_codegen.csharp.naming.class_name(
             container_cls.name
         )
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
-        cls_name_xml = aas_core_codegen.naming.xml_class_name(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
+        cls_name_xml = aas_core_codegen.naming.xml_class_name(our_type.name)
 
-        if container_cls is symbol:
+        if container_cls is our_type:
             blocks.extend(
                 _generate_for_self_contained(
                     cls_name_csharp=cls_name_csharp,

--- a/testgen/generate_test_for_xmlization_of_concrete_classes_outside_container.py
+++ b/testgen/generate_test_for_xmlization_of_concrete_classes_outside_container.py
@@ -13,13 +13,8 @@ import aas_core_codegen.csharp.naming
 import aas_core_codegen.naming
 import aas_core_codegen.parse
 import aas_core_codegen.run
-import aas_core_meta.v3rc2
-
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Stripped
-from aas_core_codegen.csharp import (
-    common as csharp_common
-)
 
 import testgen.common
 
@@ -33,28 +28,27 @@ def main() -> int:
 
     test_data_dir = repo_root / "test_data"
 
-    environment_cls = symbol_table.must_find(
+    environment_cls = symbol_table.must_find_concrete_class(
         aas_core_codegen.common.Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
 
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.ConcreteClass):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.ConcreteClass):
             continue
 
         container_cls = testgen.common.determine_container_class(
-            cls=symbol, test_data_dir=test_data_dir,
+            cls=our_type, test_data_dir=test_data_dir,
             environment_cls=environment_cls)
 
-        if container_cls is symbol:
+        if container_cls is our_type:
             # NOTE (mristin, 2022-06-27):
             # These classes are tested already in TestXmlizationOfConcreteClasses.
             # We only need to test for class instances contained in a container.
             continue
 
-        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(symbol.name)
+        cls_name_csharp = aas_core_codegen.csharp.naming.class_name(our_type.name)
 
         blocks.append(
             Stripped(

--- a/testgen/generate_test_for_xmlization_of_interfaces.py
+++ b/testgen/generate_test_for_xmlization_of_interfaces.py
@@ -26,25 +26,25 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.Class):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.Class):
             continue
 
-        if symbol.interface is None or len(symbol.interface.implementers) == 0:
+        if our_type.interface is None or len(our_type.interface.implementers) == 0:
             continue
 
-        if symbol.name == aas_core_codegen.common.Identifier("Event_payload"):
+        if our_type.name == aas_core_codegen.common.Identifier("Event_payload"):
             # NOTE (mristin, 2022-06-21):
             # Event payload is a dangling class and can not be reached from
             # the environment. Hence, we skip it.
             continue
 
-        for cls in symbol.interface.implementers:
+        for cls in our_type.interface.implementers:
             if cls.serialization is None or not cls.serialization.with_model_type:
                 continue
 
             interface_name_csharp = aas_core_codegen.csharp.naming.interface_name(
-                symbol.interface.name
+                our_type.interface.name
             )
 
             cls_name_csharp = aas_core_codegen.csharp.naming.class_name(cls.name)

--- a/testgen/generate_test_verification_of_enums.py
+++ b/testgen/generate_test_verification_of_enums.py
@@ -1,7 +1,6 @@
 """Generate the test code for the verification of enums."""
 
 import io
-import json
 import os
 import pathlib
 import sys
@@ -14,13 +13,8 @@ import aas_core_codegen.csharp.naming
 import aas_core_codegen.naming
 import aas_core_codegen.parse
 import aas_core_codegen.run
-import aas_core_meta.v3rc2
-
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Stripped
-from aas_core_codegen.csharp import (
-    common as csharp_common
-)
 
 from testgen.common import load_symbol_table
 
@@ -32,18 +26,18 @@ def main() -> int:
     # noinspection PyListCreation
     blocks = []  # type: List[str]
 
-    for symbol in symbol_table.symbols:
-        if not isinstance(symbol, intermediate.Enumeration):
+    for our_type in symbol_table.our_types:
+        if not isinstance(our_type, intermediate.Enumeration):
             continue
 
-        enum_name = aas_core_codegen.csharp.naming.enum_name(symbol.name)
+        enum_name = aas_core_codegen.csharp.naming.enum_name(our_type.name)
 
-        assert len(symbol.literals) > 0, (
-            f"Unexpected enumeration without literals: {symbol.name}"
+        assert len(our_type.literals) > 0, (
+            f"Unexpected enumeration without literals: {our_type.name}"
         )
 
         literal_name = aas_core_codegen.csharp.naming.enum_literal_name(
-            symbol.literals[0].name
+            our_type.literals[0].name
         )
 
         blocks.append(

--- a/testgen/requirements.txt
+++ b/testgen/requirements.txt
@@ -1,2 +1,2 @@
 aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@11edba5#egg=aas-core-meta
-aas-core-codegen==0.0.15
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9a0b74b#egg=aas-core-codegen


### PR DESCRIPTION
We update the code to use [aas-core-codegen 9a0b74b]. Notably, we
propagate the renaming "symbol" to "our type", and use the novel
``must_find_*`` methods to simplify the code.

[aas-core-codegen 9a0b74b]: https://github.com/aas-core-works/aas-core-codegen/commit/9a0b74b