### PR TITLE
Add opinionated-usings to pre-commit checks

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -32,8 +32,24 @@
   <component name="ChangeListManager">
     <list default="true" id="9320e216-0e07-4101-8ce3-cd62bc1769d1" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/CommonJsonization.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/CommonJsonization.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClasses.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClasses.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes.py" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideContainer.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideContainer.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestOverXOrEmpty.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestOverXOrEmpty.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClasses.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClasses.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClassesOutsideContainer.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClassesOutsideContainer.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/jsonization.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/jsonization.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/reporting.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/reporting.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/stringification.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/stringification.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/types.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/types.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/verification.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/verification.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/xmlization.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/xmlization.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test_data/Xml/SelfContained/Unexpected/MinLengthViolation/dataSpecification/id.xml.errors" beforeDir="false" afterPath="$PROJECT_DIR$/test_data/Xml/SelfContained/Unexpected/MinLengthViolation/dataSpecification/id.xml.errors" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -72,7 +88,7 @@
       <recent name="C:\Users\rist\workspace\aas-core-works\aas-core3.0rc02-csharp\src" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.generate_test_for_jsonization_of_concrete_classes">
+  <component name="RunManager" selected="Python.generate_all">
     <configuration name="generate_all" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="aas-core3.0rc02-csharp" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -86,6 +102,69 @@
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
       <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_all.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="generate_common_jsonization" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="aas-core3.0rc02-csharp" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_common_jsonization.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="generate_test_for_descend_and_visitor_through" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="aas-core3.0rc02-csharp" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_descend_and_visitor_through.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="generate_test_for_descend_once" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="aas-core3.0rc02-csharp" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_descend_once.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -115,76 +194,13 @@
       <option name="INPUT_FILE" value="" />
       <method v="2" />
     </configuration>
-    <configuration name="generate_test_for_jsonization_of_concrete_classes_outside_container" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
-      <module name="aas-core3.0rc02-csharp" />
-      <option name="INTERPRETER_OPTIONS" value="" />
-      <option name="PARENT_ENVS" value="true" />
-      <envs>
-        <env name="PYTHONUNBUFFERED" value="1" />
-      </envs>
-      <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
-      <option name="IS_MODULE_SDK" value="true" />
-      <option name="ADD_CONTENT_ROOTS" value="true" />
-      <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py" />
-      <option name="PARAMETERS" value="" />
-      <option name="SHOW_COMMAND_LINE" value="false" />
-      <option name="EMULATE_TERMINAL" value="false" />
-      <option name="MODULE_MODE" value="false" />
-      <option name="REDIRECT_INPUT" value="false" />
-      <option name="INPUT_FILE" value="" />
-      <method v="2" />
-    </configuration>
-    <configuration name="generate_test_for_over_X_or_empty" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
-      <module name="aas-core3.0rc02-csharp" />
-      <option name="INTERPRETER_OPTIONS" value="" />
-      <option name="PARENT_ENVS" value="true" />
-      <envs>
-        <env name="PYTHONUNBUFFERED" value="1" />
-      </envs>
-      <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
-      <option name="IS_MODULE_SDK" value="true" />
-      <option name="ADD_CONTENT_ROOTS" value="true" />
-      <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_over_X_or_empty.py" />
-      <option name="PARAMETERS" value="" />
-      <option name="SHOW_COMMAND_LINE" value="false" />
-      <option name="EMULATE_TERMINAL" value="false" />
-      <option name="MODULE_MODE" value="false" />
-      <option name="REDIRECT_INPUT" value="false" />
-      <option name="INPUT_FILE" value="" />
-      <method v="2" />
-    </configuration>
-    <configuration name="generate_test_for_xmlization_of_interfaces" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
-      <module name="aas-core3.0rc02-csharp" />
-      <option name="INTERPRETER_OPTIONS" value="" />
-      <option name="PARENT_ENVS" value="true" />
-      <envs>
-        <env name="PYTHONUNBUFFERED" value="1" />
-      </envs>
-      <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/testgen" />
-      <option name="IS_MODULE_SDK" value="true" />
-      <option name="ADD_CONTENT_ROOTS" value="true" />
-      <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/testgen/generate_test_for_xmlization_of_interfaces.py" />
-      <option name="PARAMETERS" value="" />
-      <option name="SHOW_COMMAND_LINE" value="false" />
-      <option name="EMULATE_TERMINAL" value="false" />
-      <option name="MODULE_MODE" value="false" />
-      <option name="REDIRECT_INPUT" value="false" />
-      <option name="INPUT_FILE" value="" />
-      <method v="2" />
-    </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Python.generate_test_for_jsonization_of_concrete_classes" />
         <item itemvalue="Python.generate_all" />
-        <item itemvalue="Python.generate_test_for_over_X_or_empty" />
-        <item itemvalue="Python.generate_test_for_jsonization_of_concrete_classes_outside_container" />
-        <item itemvalue="Python.generate_test_for_xmlization_of_interfaces" />
+        <item itemvalue="Python.generate_test_for_descend_once" />
+        <item itemvalue="Python.generate_test_for_descend_and_visitor_through" />
+        <item itemvalue="Python.generate_common_jsonization" />
+        <item itemvalue="Python.generate_test_for_jsonization_of_concrete_classes" />
       </list>
     </recent_temporary>
   </component>

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -25,6 +25,18 @@
       "commands": [
         "reportgenerator"
       ]
+    },
+    "bitesized": {
+      "version": "2.0.0",
+      "commands": [
+        "bite-sized"
+      ]
+    },
+    "opinionatedusings": {
+      "version": "1.0.0",
+      "commands": [
+        "opinionated-usings"
+      ]
     }
   }
 }

--- a/src/AasCore.Aas3_0_RC02.Tests/Common.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/Common.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Generic; // can't alias
+﻿using Aas = AasCore.Aas3_0_RC02; // renamed
+
+using System.Collections.Generic; // can't alias
 using System.Linq; // can't alias
 using NUnit.Framework; // can't alias
-using Aas = AasCore.Aas3_0_RC02; // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/CommonJson.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/CommonJson.cs
@@ -1,13 +1,11 @@
-﻿using System;
+﻿using Aas = AasCore.Aas3_0_RC02;  // renamed
 using FileMode = System.IO.FileMode;
 using FileStream = System.IO.FileStream;
-using Nodes = System.Text.Json.Nodes;
 using JsonException = System.Text.Json.JsonException;
+using Nodes = System.Text.Json.Nodes;
 
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -56,14 +54,14 @@ namespace AasCore.Aas3_0_RC02.Tests
                     return Nodes.JsonValue.Create(aDouble);
                 case string aString:
                     return Nodes.JsonValue.Create(aString)
-                        ?? throw new InvalidOperationException(
+                        ?? throw new System.InvalidOperationException(
                             $"Could not convert {something} " +
                             "to a JSON string");
                 case byte[] someBytes:
                     return Nodes.JsonValue.Create(
                         System.Convert.ToBase64String(
                             someBytes))
-                        ?? throw new InvalidOperationException(
+                        ?? throw new System.InvalidOperationException(
                             $"Could not convert {something} to " +
                             "a base64-encoded JSON string");
                 case Aas.IClass instance:

--- a/src/AasCore.Aas3_0_RC02.Tests/CommonJsonization.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/CommonJsonization.cs
@@ -3,9 +3,8 @@
  * Do NOT edit or append.
  */
 
-using Path = System.IO.Path;
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+using Path = System.IO.Path;
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestDescendAndVisitorThrough.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
 using NUnit.Framework; // can't alias
 using System.Collections.Generic;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestDescendOnce.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestDescendOnce.cs
@@ -3,12 +3,11 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
 using NUnit.Framework; // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClasses.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClasses.cs
@@ -3,6 +3,7 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Nodes = System.Text.Json.Nodes;
 using Path = System.IO.Path;
@@ -10,8 +11,6 @@ using Path = System.IO.Path;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 using NUnit.Framework; // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideContainer.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfConcreteClassesOutsideContainer.cs
@@ -3,9 +3,9 @@
  * Do NOT edit or append.
  */
 
-using NUnit.Framework; // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework; // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfEnums.cs
@@ -3,11 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Nodes = System.Text.Json.Nodes;
 
 using NUnit.Framework;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestJsonizationOfInterfaces.cs
@@ -3,9 +3,9 @@
  * Do NOT edit or append.
  */
 
-using NUnit.Framework;  // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestOverXOrEmpty.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestOverXOrEmpty.cs
@@ -3,9 +3,9 @@
  * Do NOT edit or append.
  */
 
-using NUnit.Framework;  // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfEnums.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
+
 using System.Linq;  // can't alias
 using NUnit.Framework;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfPatterns.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestVerificationOfPatterns.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+﻿using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {
@@ -11,7 +11,49 @@ namespace AasCore.Aas3_0_RC02.Tests
             // uschar is part of the regular expression for xs:AnyURI.
 
             var ucscharRe = new System.Text.RegularExpressions.Regex(
-                "([\\xa0-\\ud7ff\\uf900-\\ufdcf\\ufdf0-\\uffef]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\ud83e][\\udc00-\\udfff]|\\ud83f[\\udc00-\\udffd]|\\ud840[\\udc00-\\udfff]|[\\ud841-\\ud87e][\\udc00-\\udfff]|\\ud87f[\\udc00-\\udffd]|\\ud880[\\udc00-\\udfff]|[\\ud881-\\ud8be][\\udc00-\\udfff]|\\ud8bf[\\udc00-\\udffd]|\\ud8c0[\\udc00-\\udfff]|[\\ud8c1-\\ud8fe][\\udc00-\\udfff]|\\ud8ff[\\udc00-\\udffd]|\\ud900[\\udc00-\\udfff]|[\\ud901-\\ud93e][\\udc00-\\udfff]|\\ud93f[\\udc00-\\udffd]|\\ud940[\\udc00-\\udfff]|[\\ud941-\\ud97e][\\udc00-\\udfff]|\\ud97f[\\udc00-\\udffd]|\\ud980[\\udc00-\\udfff]|[\\ud981-\\ud9be][\\udc00-\\udfff]|\\ud9bf[\\udc00-\\udffd]|\\ud9c0[\\udc00-\\udfff]|[\\ud9c1-\\ud9fe][\\udc00-\\udfff]|\\ud9ff[\\udc00-\\udffd]|\\uda00[\\udc00-\\udfff]|[\\uda01-\\uda3e][\\udc00-\\udfff]|\\uda3f[\\udc00-\\udffd]|\\uda40[\\udc00-\\udfff]|[\\uda41-\\uda7e][\\udc00-\\udfff]|\\uda7f[\\udc00-\\udffd]|\\uda80[\\udc00-\\udfff]|[\\uda81-\\udabe][\\udc00-\\udfff]|\\udabf[\\udc00-\\udffd]|\\udac0[\\udc00-\\udfff]|[\\udac1-\\udafe][\\udc00-\\udfff]|\\udaff[\\udc00-\\udffd]|\\udb00[\\udc00-\\udfff]|[\\udb01-\\udb3e][\\udc00-\\udfff]|\\udb3f[\\udc00-\\udffd]|\\udb44[\\udc00-\\udfff]|[\\udb45-\\udb7e][\\udc00-\\udfff]|\\udb7f[\\udc00-\\udffd])");
+                "([\\xa0-\\ud7ff\\uf900-\\ufdcf\\ufdf0-\\uffef]|" +
+"\\ud800[\\udc00-\\udfff]|" +
+"[\\ud801-\\ud83e][\\udc00-\\udfff]|" +
+"\\ud83f[\\udc00-\\udffd]|" +
+"\\ud840[\\udc00-\\udfff]|" +
+"[\\ud841-\\ud87e][\\udc00-\\udfff]|" +
+"\\ud87f[\\udc00-\\udffd]|" +
+"\\ud880[\\udc00-\\udfff]|" +
+"[\\ud881-\\ud8be][\\udc00-\\udfff]|" +
+"\\ud8bf[\\udc00-\\udffd]|" +
+"\\ud8c0[\\udc00-\\udfff]|" +
+"[\\ud8c1-\\ud8fe][\\udc00-\\udfff]|" +
+"\\ud8ff[\\udc00-\\udffd]|" +
+"\\ud900[\\udc00-\\udfff]|" +
+"[\\ud901-\\ud93e][\\udc00-\\udfff]|" +
+"\\ud93f[\\udc00-\\udffd]|" +
+"\\ud940[\\udc00-\\udfff]|" +
+"[\\ud941-\\ud97e][\\udc00-\\udfff]|" +
+"\\ud97f[\\udc00-\\udffd]|" +
+"\\ud980[\\udc00-\\udfff]|" +
+"[\\ud981-\\ud9be][\\udc00-\\udfff]|" +
+"\\ud9bf[\\udc00-\\udffd]|" +
+"\\ud9c0[\\udc00-\\udfff]|" +
+"[\\ud9c1-\\ud9fe][\\udc00-\\udfff]|" +
+"\\ud9ff[\\udc00-\\udffd]|" +
+"\\uda00[\\udc00-\\udfff]|" +
+"[\\uda01-\\uda3e][\\udc00-\\udfff]|" +
+"\\uda3f[\\udc00-\\udffd]|" +
+"\\uda40[\\udc00-\\udfff]|" +
+"[\\uda41-\\uda7e][\\udc00-\\udfff]|" +
+"\\uda7f[\\udc00-\\udffd]|" +
+"\\uda80[\\udc00-\\udfff]|" +
+"[\\uda81-\\udabe][\\udc00-\\udfff]|" +
+"\\udabf[\\udc00-\\udffd]|" +
+"\\udac0[\\udc00-\\udfff]|" +
+"[\\udac1-\\udafe][\\udc00-\\udfff]|" +
+"\\udaff[\\udc00-\\udffd]|" +
+"\\udb00[\\udc00-\\udfff]|" +
+"[\\udb01-\\udb3e][\\udc00-\\udfff]|" +
+"\\udb3f[\\udc00-\\udffd]|" +
+"\\udb44[\\udc00-\\udfff]|" +
+"[\\udb45-\\udb7e][\\udc00-\\udfff]|" +
+"\\udb7f[\\udc00-\\udffd])");
 
             const string text = "\ud8e8\ude54";
             Assert.IsTrue(ucscharRe.IsMatch(text));

--- a/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestXOrDefault.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Nodes = System.Text.Json.Nodes;
 using Path = System.IO.Path;
 
 using NUnit.Framework;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClasses.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClasses.cs
@@ -3,6 +3,7 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
@@ -10,8 +11,6 @@ using NUnit.Framework; // can't alias
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 using System.Xml.Linq; // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClassesOutsideContainer.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfConcreteClassesOutsideContainer.cs
@@ -3,9 +3,9 @@
  * Do NOT edit or append.
  */
 
-using NUnit.Framework; // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework; // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfInterfaces.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestXmlizationOfInterfaces.cs
@@ -3,9 +3,9 @@
  * Do NOT edit or append.
  */
 
-using NUnit.Framework;  // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02.Tests/XmlPlayground.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/XmlPlayground.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+﻿using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/src/AasCore.Aas3_0_RC02/jsonization.cs
+++ b/src/AasCore.Aas3_0_RC02/jsonization.cs
@@ -3,11 +3,11 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Nodes = System.Text.Json.Nodes;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/src/AasCore.Aas3_0_RC02/reporting.cs
+++ b/src/AasCore.Aas3_0_RC02/reporting.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/src/AasCore.Aas3_0_RC02/stringification.cs
+++ b/src/AasCore.Aas3_0_RC02/stringification.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/src/AasCore.Aas3_0_RC02/types.cs
+++ b/src/AasCore.Aas3_0_RC02/types.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/src/AasCore.Aas3_0_RC02/verification.cs
+++ b/src/AasCore.Aas3_0_RC02/verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/src/AasCore.Aas3_0_RC02/xmlization.cs
+++ b/src/AasCore.Aas3_0_RC02/xmlization.cs
@@ -3,11 +3,11 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Xml = System.Xml;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -19,6 +19,20 @@ function Main
         throw "Format check failed."
     }
 
+    Write-Host "${nl}Check.ps1: Inspecting the code with bite-sized...${nl}"
+
+    # NOTE (mristin, 2022-07-23):
+    # We ignore the lines where regexes were transpiled since breaking regex into
+    # multiple lines in a meaningful way is a difficult problem to get right.
+    dotnet bite-sized `
+        --inputs "AasCore.*/*.cs" `
+        --max-line-length 200 `
+        --max-lines-in-file 100000 `
+        --ignore-lines-matching '^ +var [a-zA-Z0-9_]+ = ".+";'
+
+    Write-Host "${nl}Check.ps1: Inspecting the code with opinionated-usings...${nl}"
+    dotnet opinionated-usings --inputs "AasCore.*/*.cs"
+
     $env:AAS_CORE_AAS3_0_RC02_TESTS_TEST_DATA_DIR = (
         Join-Path (Split-Path $PSScriptRoot -Parent) "test_data"
     )

--- a/testgen/generate_common_jsonization.py
+++ b/testgen/generate_common_jsonization.py
@@ -119,9 +119,8 @@ public static Aas.{cls_name_csharp} LoadMinimal{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
-using Path = System.IO.Path;
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+using Path = System.IO.Path;
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_descend_and_visitor_through.py
+++ b/testgen/generate_test_for_descend_and_visitor_through.py
@@ -196,13 +196,12 @@ public void Test_Descend_against_VisitorThrough_for_{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
 using NUnit.Framework; // can't alias
 using System.Collections.Generic;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_descend_once.py
+++ b/testgen/generate_test_for_descend_once.py
@@ -132,12 +132,11 @@ public void Test_{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
 using NUnit.Framework; // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_get_X_or_default.py
+++ b/testgen/generate_test_for_get_X_or_default.py
@@ -170,13 +170,12 @@ public void Test_{cls_name_csharp}_{method_name_csharp}_default()
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Nodes = System.Text.Json.Nodes;
 using Path = System.IO.Path;
 
 using NUnit.Framework;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_concrete_classes.py
+++ b/testgen/generate_test_for_jsonization_of_concrete_classes.py
@@ -487,6 +487,7 @@ private static void AssertEqualsExpectedOrRerecordDeserializationException(
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Nodes = System.Text.Json.Nodes;
 using Path = System.IO.Path;
@@ -494,8 +495,6 @@ using Path = System.IO.Path;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 using NUnit.Framework; // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py
+++ b/testgen/generate_test_for_jsonization_of_concrete_classes_outside_container.py
@@ -92,9 +92,9 @@ public void Test_round_trip_{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
-using NUnit.Framework; // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework; // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_enums.py
+++ b/testgen/generate_test_for_jsonization_of_enums.py
@@ -75,11 +75,10 @@ public void Test_round_trip_{enum_name}()
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Nodes = System.Text.Json.Nodes;
 
 using NUnit.Framework;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_jsonization_of_interfaces.py
+++ b/testgen/generate_test_for_jsonization_of_interfaces.py
@@ -90,9 +90,9 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
-using NUnit.Framework;  // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_over_X_or_empty.py
+++ b/testgen/generate_test_for_over_X_or_empty.py
@@ -87,9 +87,9 @@ public void Test_{cls_name_csharp}_{method_name_csharp}_default()
  * Do NOT edit or append.
  */
 
-using NUnit.Framework;  // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_xmlization_of_concrete_classes.py
+++ b/testgen/generate_test_for_xmlization_of_concrete_classes.py
@@ -529,6 +529,7 @@ private static void AssertEqualsExpectedOrRerecordDeserializationException(
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using Directory = System.IO.Directory;
 using Path = System.IO.Path;
 
@@ -536,8 +537,6 @@ using NUnit.Framework; // can't alias
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 using System.Xml.Linq; // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_xmlization_of_concrete_classes_outside_container.py
+++ b/testgen/generate_test_for_xmlization_of_concrete_classes_outside_container.py
@@ -126,9 +126,9 @@ public void Test_round_trip_{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
-using NUnit.Framework; // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework; // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_for_xmlization_of_interfaces.py
+++ b/testgen/generate_test_for_xmlization_of_interfaces.py
@@ -126,9 +126,9 @@ public void Test_round_trip_{interface_name_csharp}_from_{cls_name_csharp}()
  * Do NOT edit or append.
  */
 
-using NUnit.Framework;  // can't alias
-
 using Aas = AasCore.Aas3_0_RC02;  // renamed
+
+using NUnit.Framework;  // can't alias
 
 namespace AasCore.Aas3_0_RC02.Tests
 {

--- a/testgen/generate_test_verification_of_enums.py
+++ b/testgen/generate_test_verification_of_enums.py
@@ -75,10 +75,10 @@ public void Test_{enum_name}_invalid()
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
+
 using System.Linq;  // can't alias
 using NUnit.Framework;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;  // renamed
 
 namespace AasCore.Aas3_0_RC02.Tests
 {


### PR DESCRIPTION
We add [opinionated-usings] to the battery of pre-commit checks to make
sure that our using directives are consistent and readable. This change
also fixes the code so that the checks pass.

[opinionated-usings]: https://github.com/mristin/opinionated-usings-csharp/