### PR TITLE
Fix publishing command in the workflow

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -34,4 +34,4 @@ jobs:
         working-directory: src/AasCore.Aas3_0_RC02
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_KEY}}
-        run: dotnet nuget push out\*.nupkg --skip-duplicate --no-symbols true --source https://api.nuget.org/v3/index.json -k $env:NUGET_AUTH_TOKEN
+        run: dotnet nuget push out\*.nupkg --skip-duplicate --no-symbols --source https://api.nuget.org/v3/index.json -k $env:NUGET_AUTH_TOKEN


### PR DESCRIPTION
We fix the publishing workflow and remove an unnecessary argument
(`true`) which caused a misleading error message.