### PR TITLE
Fix DocFX not rendering the API

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
+      - mristin/Fix-docfx-not-rendering-API
 
 jobs:
   Generate-doc:
-    runs-on: windows-latest
+    # We need to use windows-2019 due to the bug in MSBuild in VS Studio 17.3.3
+    # which is shipped with GitHub's windows-latest image.
+    # See: https://github.com/dotnet/docfx/issues/8097
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@master
 

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="83706ea3-1c99-49d2-8237-0e5982ac8a2f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.github/workflows/doc.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/doc.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />


### PR DESCRIPTION
We face the issue from https://github.com/dotnet/docfx/issues/8097.
We fix it by downgrading to windows-2019 image in the CI, since that
image contains VisualStudio 2019, where the issue does not arise.
