### PR TITLE
Test for examples from the documentations

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,8 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="83706ea3-1c99-49d2-8237-0e5982ac8a2f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/AasCore.Aas3_0_RC02.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/AasCore.Aas3_0_RC02.csproj" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestExamples.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/doc/source/getting_started/xmlize.md" beforeDir="false" afterPath="$PROJECT_DIR$/doc/source/getting_started/xmlize.md" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/doc/source/getting_started/xmlize.md
+++ b/doc/source/getting_started/xmlize.md
@@ -65,6 +65,8 @@ public class Program
             environment,
             writer
         );
+        
+        writer.Flush();
 
         // Print the output
         System.Console.WriteLine(

--- a/src/AasCore.Aas3_0_RC02.Tests/TestExamples.cs
+++ b/src/AasCore.Aas3_0_RC02.Tests/TestExamples.cs
@@ -1,0 +1,69 @@
+﻿using Aas = AasCore.Aas3_0_RC02; // renamed
+using AasXmlization = AasCore.Aas3_0_RC02.Xmlization; // renamed
+
+using NUnit.Framework; // can't alias
+using System.Collections.Generic;  // can't alias
+
+namespace AasCore.Aas3_0_RC02.Tests
+{
+    public class TestExamples
+    {
+        /// <summary>
+        /// Correspond to: https://dotnetfiddle.net/VEL2jU#
+        /// </summary>
+        [Test]
+        public void Test_XML_serialization()
+        {
+            // Prepare the environment
+            var someProperty = new Aas.Property(
+                Aas.DataTypeDefXsd.Boolean)
+            {
+                IdShort = "someProperty",
+            };
+
+            var submodel = new Aas.Submodel(
+                "some-unique-global-identifier")
+            {
+                SubmodelElements = new List<Aas.ISubmodelElement>()
+                {
+                    someProperty
+                }
+            };
+
+            var environment = new Aas.Environment()
+            {
+                Submodels = new List<Aas.Submodel>()
+                {
+                    submodel
+                }
+            };
+
+            // Serialize to an XML writer
+            var outputBuilder = new System.Text.StringBuilder();
+
+            using var writer = System.Xml.XmlWriter.Create(
+                outputBuilder,
+                new System.Xml.XmlWriterSettings()
+                {
+                    Encoding = System.Text.Encoding.UTF8,
+                    OmitXmlDeclaration = true
+                }
+            );
+
+            AasXmlization.Serialize.To(
+                environment,
+                writer
+            );
+
+            writer.Flush();
+
+            Assert.AreEqual(
+                "<environment xmlns=\"https://admin-shell.io/aas/3/0/RC02\">" +
+                "<submodels><submodel><id>some-unique-global-identifier</id>" +
+                "<submodelElements><property><idShort>someProperty</idShort>" +
+                "<valueType>xs:boolean</valueType></property></submodelElements>" +
+                "</submodel></submodels></environment>",
+                outputBuilder.ToString());
+        }
+    }
+}


### PR DESCRIPTION
As reported in [the issue #66], the example snippet for serializing XML
was wrong. We fix the example, and add a unit test to prevent
regressions.

Fixes #66.

[the issue #66]: https://github.com/aas-core-works/aas-core3.0rc02-csharp/issues/66