### PR TITLE
Fix XML namespace in documentation examples

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,8 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="83706ea3-1c99-49d2-8237-0e5982ac8a2f" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02.Tests/TestExamples.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/doc/source/getting_started/xmlize.md" beforeDir="false" afterPath="$PROJECT_DIR$/doc/source/getting_started/xmlize.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/doc/source/getting_started/xmlize.md
+++ b/doc/source/getting_started/xmlize.md
@@ -74,7 +74,7 @@ public class Program
         );
 
         // Outputs (all on a single line):
-        // <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+        // <environment xmlns="https://admin-shell.io/aas/3/0/RC02">
         // <submodels><submodel><id>some-unique-global-identifier</id>
         // <submodelElements><property><idShort>someProperty</idShort>
         // <valueType>xs:boolean</valueType></property></submodelElements>
@@ -106,7 +106,7 @@ public class Program
     public static void Main()
     {
         var text = (
-            "<environment xmlns=\"http://www.admin-shell.io/aas/3/0/RC02\">" +
+            "<environment xmlns=\"https://admin-shell.io/aas/3/0/RC02\">" +
             "<submodels><submodel><id>some-unique-global-identifier</id>" +
             "<submodelElements><property><idShort>someProperty</idShort>" +
             "<valueType>xs:boolean</valueType></property></submodelElements>" +


### PR DESCRIPTION
We fix the examples in the documentation related to XML de/serialization.
Originally, we used `http://www.` prefix in the XML namespace, but after
a couple of reviews, the namespace prefix was settled to `https://` 
(https protocol and no ``www``).

We forgot to propagate this change to the documentation.