### PR TITLE
Fix paths in xmlization exceptions

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="83706ea3-1c99-49d2-8237-0e5982ac8a2f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/testgen/requirements.txt" beforeDir="false" afterPath="$PROJECT_DIR$/testgen/requirements.txt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -20,18 +20,18 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "settings.editor.selected.configurable": "com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable&quot;
   },
-  "keyToStringList": {
-    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
-      "JSON"
+  &quot;keyToStringList&quot;: {
+    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
+      &quot;JSON&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration name="generate_all" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="aas-core3.0rc02-csharp" />

--- a/src/AasCore.Aas3_0_RC02/reporting.cs
+++ b/src/AasCore.Aas3_0_RC02/reporting.cs
@@ -94,9 +94,9 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Escape special characters according to XML.
+        /// Escape special characters for XPath.
         /// </summary>
-        private static string EscapeXmlCharacters(
+        private static string EscapeForXPath(
             string text)
         {
             // Mind the order, as we need to replace '&' first.
@@ -105,7 +105,10 @@ namespace AasCore.Aas3_0_RC02
             // https://stackoverflow.com/questions/1321331/replace-multiple-string-elements-in-c-sharp
             return (
                 text
+                    // Even though ampersand, less-then etc. can not occur in valid element names,
+                    // we escape them here for easier debugging and better bug reports.
                     .Replace("&", "&amp;")
+                    .Replace("/", "&#47;")
                     .Replace("<", "&lt;")
                     .Replace(">", "&gt;")
                     .Replace("\"", "&quot;")
@@ -130,7 +133,7 @@ namespace AasCore.Aas3_0_RC02
                 switch (segment)
                 {
                     case NameSegment nameSegment:
-                        part = EscapeXmlCharacters(nameSegment.Name);
+                        part = EscapeForXPath(nameSegment.Name);
                         break;
                     case IndexSegment indexSegment:
                         part = $"*[{indexSegment.Index}]";

--- a/src/AasCore.Aas3_0_RC02/verification.cs
+++ b/src/AasCore.Aas3_0_RC02/verification.cs
@@ -111,7 +111,8 @@ namespace AasCore.Aas3_0_RC02
         /// exactly four digits.
         ///
         /// We strip the negative sign and assume astronomical years.
-        /// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm
+        /// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm and
+        /// the note at: https://www.w3.org/TR/xmlschema-2/#dateTime
         ///
         /// Furthermore, we always assume that <paramref name="value" /> has been
         /// already validated with the corresponding regular expression.
@@ -143,10 +144,6 @@ namespace AasCore.Aas3_0_RC02
         /// Check that <paramref name="value" /> is a <c>xs:dateTimeStamp</c> with
         /// the time zone set to UTC.
         /// </summary>
-        /// <remarks>
-        /// The <paramref name="value" /> is assumed to be already checked with
-        /// <see cref="MatchesXsDateTimeStampUtc" />.
-        /// </remarks>
         public static bool IsXsDateTimeStampUtc(
             string value
         )
@@ -2077,10 +2074,10 @@ namespace AasCore.Aas3_0_RC02
 
         public static bool SubmodelElementIsOfType(
             Aas.ISubmodelElement element,
-            Aas.AasSubmodelElements elementType
+            Aas.AasSubmodelElements expectedType
         )
         {
-            switch (elementType)
+            switch (expectedType)
             {
                 case Aas.AasSubmodelElements.AnnotatedRelationshipElement:
                     return element is Aas.AnnotatedRelationshipElement;
@@ -2137,7 +2134,7 @@ namespace AasCore.Aas3_0_RC02
 
                 default:
                     throw new System.ArgumentException(
-                        $"elementType is not a valid AasSubmodelElements: {elementType}"
+                        $"expectedType is not a valid AasSubmodelElements: {expectedType}"
                     );
             }
         }
@@ -2375,15 +2372,20 @@ namespace AasCore.Aas3_0_RC02
                         return false;
                     }
 
+                    var noDefinitionInEnglish = true;
                     foreach (var langString in iec61360.Definition)
                     {
                         if (IsBcp47ForEnglish(langString.Language))
                         {
-                            return true;
+                            noDefinitionInEnglish = false;
+                            break;
                         }
                     }
 
-                    return false;
+                    if (noDefinitionInEnglish)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/AasCore.Aas3_0_RC02/xmlization.cs
+++ b/src/AasCore.Aas3_0_RC02/xmlization.cs
@@ -281,6 +281,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -1117,6 +1120,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -1548,6 +1554,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -2029,6 +2038,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -2142,6 +2154,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -2175,6 +2190,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -2302,6 +2320,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -2363,6 +2384,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSubmodels));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "submodels"));
                                                 return null;
                                             }
 
@@ -2706,6 +2730,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSpecificAssetIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "specificAssetIds"));
                                                 return null;
                                             }
 
@@ -3290,6 +3317,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -3671,6 +3701,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -3784,6 +3817,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -3817,6 +3853,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -4013,6 +4052,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -4046,6 +4088,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -4079,6 +4124,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -4112,6 +4160,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSubmodelElements));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "submodelElements"));
                                                 return null;
                                             }
 
@@ -4473,6 +4524,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -4586,6 +4640,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -4619,6 +4676,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -4761,6 +4821,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -4794,6 +4857,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -4827,6 +4893,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -5192,6 +5261,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -5305,6 +5377,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -5338,6 +5413,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -5480,6 +5558,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -5513,6 +5594,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -5546,6 +5630,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -5626,6 +5713,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexValue));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "value"));
                                                 return null;
                                             }
 
@@ -6026,6 +6116,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -6139,6 +6232,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -6172,6 +6268,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -6314,6 +6413,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -6347,6 +6449,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -6380,6 +6485,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -6413,6 +6521,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexValue));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "value"));
                                                 return null;
                                             }
 
@@ -6739,6 +6850,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -6852,6 +6966,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -6885,6 +7002,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -7027,6 +7147,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -7060,6 +7183,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -7093,6 +7219,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -7477,6 +7606,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -7590,6 +7722,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -7623,6 +7758,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -7765,6 +7903,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -7798,6 +7939,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -7831,6 +7975,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -7864,6 +8011,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexValue));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "value"));
                                                 return null;
                                             }
 
@@ -8143,6 +8293,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -8256,6 +8409,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -8289,6 +8445,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -8431,6 +8590,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -8464,6 +8626,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -8497,6 +8662,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -8906,6 +9074,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -9019,6 +9190,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -9052,6 +9226,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -9194,6 +9371,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -9227,6 +9407,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -9260,6 +9443,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -9537,6 +9723,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -9650,6 +9839,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -9683,6 +9875,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -9825,6 +10020,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -9858,6 +10056,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -9891,6 +10092,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -10253,6 +10457,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -10366,6 +10573,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -10399,6 +10609,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -10541,6 +10754,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -10574,6 +10790,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -10607,6 +10826,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -10962,6 +11184,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -11075,6 +11300,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -11108,6 +11336,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -11250,6 +11481,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -11283,6 +11517,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -11316,6 +11553,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -11377,6 +11617,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexAnnotations));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "annotations"));
                                                 return null;
                                             }
 
@@ -11664,6 +11907,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -11777,6 +12023,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -11810,6 +12059,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -11952,6 +12204,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -11985,6 +12240,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -12018,6 +12276,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -12051,6 +12312,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexStatements));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "statements"));
                                                 return null;
                                             }
 
@@ -12904,6 +13168,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -13017,6 +13284,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -13050,6 +13320,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -13192,6 +13465,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -13225,6 +13501,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -13258,6 +13537,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -13857,6 +14139,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -13970,6 +14255,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -14003,6 +14291,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -14145,6 +14436,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -14178,6 +14472,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -14211,6 +14508,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -14244,6 +14544,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexInputVariables));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "inputVariables"));
                                                 return null;
                                             }
 
@@ -14277,6 +14580,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexOutputVariables));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "outputVariables"));
                                                 return null;
                                             }
 
@@ -14310,6 +14616,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexInoutputVariables));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "inoutputVariables"));
                                                 return null;
                                             }
 
@@ -14555,6 +14864,10 @@ namespace AasCore.Aas3_0_RC02
                                         return null;
                                     }
 
+                                    // We need to skip the whitespace here in order to be able to look ahead
+                                    // the discriminator element shortly.
+                                    SkipNoneWhitespaceAndComments(reader);
+
                                     if (reader.EOF)
                                     {
                                         error = new Reporting.Error(
@@ -14564,11 +14877,28 @@ namespace AasCore.Aas3_0_RC02
                                         return null;
                                     }
 
+                                    // Try to look ahead the discriminator name;
+                                    // we need this name only for the error reporting below.
+                                    // ISubmodelElementFromElement will perform more sophisticated
+                                    // checks.
+                                    string? discriminatorElementName = null;
+                                    if (reader.NodeType == Xml.XmlNodeType.Element)
+                                    {
+                                        discriminatorElementName = reader.LocalName;
+                                    }
+
                                     theValue = ISubmodelElementFromElement(
                                         reader, out error);
 
                                     if (error != null)
                                     {
+                                        if (discriminatorElementName != null)
+                                        {
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    discriminatorElementName));
+                                        }
+
                                         error.PrependSegment(
                                             new Reporting.NameSegment(
                                                 "value"));
@@ -14822,6 +15152,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -14935,6 +15268,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -14968,6 +15304,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -15110,6 +15449,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSupplementalSemanticIds));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "supplementalSemanticIds"));
                                                 return null;
                                             }
 
@@ -15143,6 +15485,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexQualifiers));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "qualifiers"));
                                                 return null;
                                             }
 
@@ -15176,6 +15521,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -15435,6 +15783,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexExtensions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "extensions"));
                                                 return null;
                                             }
 
@@ -15548,6 +15899,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDisplayName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "displayName"));
                                                 return null;
                                             }
 
@@ -15581,6 +15935,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDescription));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "description"));
                                                 return null;
                                             }
 
@@ -15708,6 +16065,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexEmbeddedDataSpecifications));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "embeddedDataSpecifications"));
                                                 return null;
                                             }
 
@@ -15741,6 +16101,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexIsCaseOf));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "isCaseOf"));
                                                 return null;
                                             }
 
@@ -16071,6 +16434,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexKeys));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "keys"));
                                                 return null;
                                             }
 
@@ -16968,6 +17334,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexAssetAdministrationShells));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "assetAdministrationShells"));
                                                 return null;
                                             }
 
@@ -17001,6 +17370,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexSubmodels));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "submodels"));
                                                 return null;
                                             }
 
@@ -17034,6 +17406,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexConceptDescriptions));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "conceptDescriptions"));
                                                 return null;
                                             }
 
@@ -17333,6 +17708,10 @@ namespace AasCore.Aas3_0_RC02
                                         return null;
                                     }
 
+                                    // We need to skip the whitespace here in order to be able to look ahead
+                                    // the discriminator element shortly.
+                                    SkipNoneWhitespaceAndComments(reader);
+
                                     if (reader.EOF)
                                     {
                                         error = new Reporting.Error(
@@ -17342,11 +17721,28 @@ namespace AasCore.Aas3_0_RC02
                                         return null;
                                     }
 
+                                    // Try to look ahead the discriminator name;
+                                    // we need this name only for the error reporting below.
+                                    // IDataSpecificationContentFromElement will perform more sophisticated
+                                    // checks.
+                                    string? discriminatorElementName = null;
+                                    if (reader.NodeType == Xml.XmlNodeType.Element)
+                                    {
+                                        discriminatorElementName = reader.LocalName;
+                                    }
+
                                     theDataSpecificationContent = IDataSpecificationContentFromElement(
                                         reader, out error);
 
                                     if (error != null)
                                     {
+                                        if (discriminatorElementName != null)
+                                        {
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    discriminatorElementName));
+                                        }
+
                                         error.PrependSegment(
                                             new Reporting.NameSegment(
                                                 "dataSpecificationContent"));
@@ -17884,6 +18280,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexValueReferencePairs));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "valueReferencePairs"));
                                                 return null;
                                             }
 
@@ -18145,6 +18544,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexPreferredName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "preferredName"));
                                                 return null;
                                             }
 
@@ -18178,6 +18580,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexShortName));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "shortName"));
                                                 return null;
                                             }
 
@@ -18400,6 +18805,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDefinition));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "definition"));
                                                 return null;
                                             }
 
@@ -18902,6 +19310,9 @@ namespace AasCore.Aas3_0_RC02
                                                 error.PrependSegment(
                                                     new Reporting.IndexSegment(
                                                         indexDefinition));
+                                                error.PrependSegment(
+                                                    new Reporting.NameSegment(
+                                                        "definition"));
                                                 return null;
                                             }
 

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/annotatedRelationshipElement/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/annotatedRelationshipElement/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class AnnotatedRelationshipElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class AnnotatedRelationshipElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/assetInformation/assetKind_as_assetKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/assetInformation/assetKind_as_assetKind.xml.exception
@@ -1,1 +1,1 @@
-The property AssetKind of an instance of class AssetInformation could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/assetInformation/assetKind
+The property AssetKind of an instance of class AssetInformation could not be de-serialized from an unexpected enumeration literal: invalid-literal at: assetAdministrationShells/*[0]/assetInformation/assetKind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/direction_as_direction.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/direction_as_direction.xml.exception
@@ -1,1 +1,1 @@
-The property Direction of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/direction
+The property Direction of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/direction

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/state_as_stateOfEvent.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/state_as_stateOfEvent.xml.exception
@@ -1,1 +1,1 @@
-The property State of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/state
+The property State of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/state

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/blob/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/blob/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Blob could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Blob could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/capability/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/capability/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Capability could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Capability could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/dataSpecificationIec61360/dataType_as_dataTypeIec61360.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/dataSpecificationIec61360/dataType_as_dataTypeIec61360.xml.exception
@@ -1,1 +1,1 @@
-The property DataType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/dataSpecificationContent/dataType
+The property DataType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: invalid-literal at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/dataType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/dataSpecificationIec61360/levelType_as_levelType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/dataSpecificationIec61360/levelType_as_levelType.xml.exception
@@ -1,1 +1,1 @@
-The property LevelType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/dataSpecificationContent/levelType
+The property LevelType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: invalid-literal at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/levelType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/entity/entityType_as_entityType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/entity/entityType_as_entityType.xml.exception
@@ -1,1 +1,1 @@
-The property EntityType of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/entityType
+The property EntityType of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/entityType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/entity/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/entity/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/extension/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/extension/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Extension could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Extension could not be de-serialized from an unexpected enumeration literal: invalid-literal at: assetAdministrationShells/*[0]/extensions/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/file/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/file/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class File could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class File could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/key/type_as_keyTypes.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/key/type_as_keyTypes.xml.exception
@@ -1,1 +1,1 @@
-The property Type of an instance of class Key could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/derivedFrom/*[0]/type
+The property Type of an instance of class Key could not be de-serialized from an unexpected enumeration literal: invalid-literal at: assetAdministrationShells/*[0]/derivedFrom/keys/*[0]/type

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/multiLanguageProperty/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/multiLanguageProperty/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class MultiLanguageProperty could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class MultiLanguageProperty could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/operation/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/operation/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Operation could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Operation could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/property/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/property/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Property could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Property could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/property/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/property/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Property could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Property could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/qualifier/kind_as_qualifierKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/qualifier/kind_as_qualifierKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/qualifiers/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/qualifier/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/qualifier/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/qualifiers/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/range/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/range/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Range could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class Range could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/range/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/range/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Range could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Range could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/reference/type_as_referenceTypes.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/reference/type_as_referenceTypes.xml.exception
@@ -1,1 +1,1 @@
-The property Type of an instance of class Reference could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/semanticId/type
+The property Type of an instance of class Reference could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/semanticId/type

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/referenceElement/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/referenceElement/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class ReferenceElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class ReferenceElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/relationshipElement/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/relationshipElement/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class RelationshipElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class RelationshipElement could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodel/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodel/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Submodel could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/kind
+The property Kind of an instance of class Submodel could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementCollection/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementCollection/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class SubmodelElementCollection could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class SubmodelElementCollection could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/kind_as_modelingKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/kind_as_modelingKind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/kind
+The property Kind of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/typeValueListElement_as_aasSubmodelElements.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/typeValueListElement_as_aasSubmodelElements.xml.exception
@@ -1,1 +1,1 @@
-The property TypeValueListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/typeValueListElement
+The property TypeValueListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/typeValueListElement

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/valueTypeListElement_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/valueTypeListElement_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-The property ValueTypeListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: invalid-literal at: *[0]/*[0]/valueTypeListElement
+The property ValueTypeListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: invalid-literal at: submodels/*[0]/submodelElements/*[0]/valueTypeListElement

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/annotatedRelationshipElement/first.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/annotatedRelationshipElement/first.xml.exception
@@ -1,1 +1,1 @@
-The required property First has not been given in the XML representation of an instance of class AnnotatedRelationshipElement at: *[0]/*[0]
+The required property First has not been given in the XML representation of an instance of class AnnotatedRelationshipElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/annotatedRelationshipElement/second.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/annotatedRelationshipElement/second.xml.exception
@@ -1,1 +1,1 @@
-The required property Second has not been given in the XML representation of an instance of class AnnotatedRelationshipElement at: *[0]/*[0]
+The required property Second has not been given in the XML representation of an instance of class AnnotatedRelationshipElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/assetAdministrationShell/assetInformation.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/assetAdministrationShell/assetInformation.xml.exception
@@ -1,1 +1,1 @@
-The required property AssetInformation has not been given in the XML representation of an instance of class AssetAdministrationShell at: *[0]
+The required property AssetInformation has not been given in the XML representation of an instance of class AssetAdministrationShell at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/assetAdministrationShell/id.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/assetAdministrationShell/id.xml.exception
@@ -1,1 +1,1 @@
-The required property Id has not been given in the XML representation of an instance of class AssetAdministrationShell at: *[0]
+The required property Id has not been given in the XML representation of an instance of class AssetAdministrationShell at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/assetInformation/assetKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/assetInformation/assetKind.xml.exception
@@ -1,1 +1,1 @@
-The required property AssetKind has not been given in the XML representation of an instance of class AssetInformation at: *[0]/assetInformation
+The required property AssetKind has not been given in the XML representation of an instance of class AssetInformation at: assetAdministrationShells/*[0]/assetInformation

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/direction.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/direction.xml.exception
@@ -1,1 +1,1 @@
-The required property Direction has not been given in the XML representation of an instance of class BasicEventElement at: *[0]/*[0]
+The required property Direction has not been given in the XML representation of an instance of class BasicEventElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/observed.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/observed.xml.exception
@@ -1,1 +1,1 @@
-The required property Observed has not been given in the XML representation of an instance of class BasicEventElement at: *[0]/*[0]
+The required property Observed has not been given in the XML representation of an instance of class BasicEventElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/state.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/state.xml.exception
@@ -1,1 +1,1 @@
-The required property State has not been given in the XML representation of an instance of class BasicEventElement at: *[0]/*[0]
+The required property State has not been given in the XML representation of an instance of class BasicEventElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/blob/contentType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/blob/contentType.xml.exception
@@ -1,1 +1,1 @@
-The required property ContentType has not been given in the XML representation of an instance of class Blob at: *[0]/*[0]
+The required property ContentType has not been given in the XML representation of an instance of class Blob at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/conceptDescription/id.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/conceptDescription/id.xml.exception
@@ -1,1 +1,1 @@
-The required property Id has not been given in the XML representation of an instance of class ConceptDescription at: *[0]
+The required property Id has not been given in the XML representation of an instance of class ConceptDescription at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationIec61360/preferredName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationIec61360/preferredName.xml.exception
@@ -1,1 +1,1 @@
-The required property PreferredName has not been given in the XML representation of an instance of class DataSpecificationIec61360 at: *[0]/*[0]/dataSpecificationContent
+The required property PreferredName has not been given in the XML representation of an instance of class DataSpecificationIec61360 at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationPhysicalUnit/definition.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationPhysicalUnit/definition.xml.exception
@@ -1,1 +1,1 @@
-The required property Definition has not been given in the XML representation of an instance of class DataSpecificationPhysicalUnit at: *[0]/*[0]/dataSpecificationContent
+The required property Definition has not been given in the XML representation of an instance of class DataSpecificationPhysicalUnit at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationPhysicalUnit/unitName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationPhysicalUnit/unitName.xml.exception
@@ -1,1 +1,1 @@
-The required property UnitName has not been given in the XML representation of an instance of class DataSpecificationPhysicalUnit at: *[0]/*[0]/dataSpecificationContent
+The required property UnitName has not been given in the XML representation of an instance of class DataSpecificationPhysicalUnit at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationPhysicalUnit/unitSymbol.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/dataSpecificationPhysicalUnit/unitSymbol.xml.exception
@@ -1,1 +1,1 @@
-The required property UnitSymbol has not been given in the XML representation of an instance of class DataSpecificationPhysicalUnit at: *[0]/*[0]/dataSpecificationContent
+The required property UnitSymbol has not been given in the XML representation of an instance of class DataSpecificationPhysicalUnit at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/embeddedDataSpecification/dataSpecification.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/embeddedDataSpecification/dataSpecification.xml.exception
@@ -1,1 +1,1 @@
-The required property DataSpecification has not been given in the XML representation of an instance of class EmbeddedDataSpecification at: *[0]/*[0]
+The required property DataSpecification has not been given in the XML representation of an instance of class EmbeddedDataSpecification at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/embeddedDataSpecification/dataSpecificationContent.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/embeddedDataSpecification/dataSpecificationContent.xml.exception
@@ -1,1 +1,1 @@
-The required property DataSpecificationContent has not been given in the XML representation of an instance of class EmbeddedDataSpecification at: *[0]/*[0]
+The required property DataSpecificationContent has not been given in the XML representation of an instance of class EmbeddedDataSpecification at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/entity/entityType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/entity/entityType.xml.exception
@@ -1,1 +1,1 @@
-The required property EntityType has not been given in the XML representation of an instance of class Entity at: *[0]/*[0]
+The required property EntityType has not been given in the XML representation of an instance of class Entity at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/extension/name.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/extension/name.xml.exception
@@ -1,1 +1,1 @@
-The required property Name has not been given in the XML representation of an instance of class Extension at: *[0]/*[0]
+The required property Name has not been given in the XML representation of an instance of class Extension at: assetAdministrationShells/*[0]/extensions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/file/contentType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/file/contentType.xml.exception
@@ -1,1 +1,1 @@
-The required property ContentType has not been given in the XML representation of an instance of class File at: *[0]/*[0]
+The required property ContentType has not been given in the XML representation of an instance of class File at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/key/type.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/key/type.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Key at: *[0]/derivedFrom/*[0]
+The required property Type has not been given in the XML representation of an instance of class Key at: assetAdministrationShells/*[0]/derivedFrom/keys/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/key/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/key/value.xml.exception
@@ -1,1 +1,1 @@
-The required property Value has not been given in the XML representation of an instance of class Key at: *[0]/derivedFrom/*[0]
+The required property Value has not been given in the XML representation of an instance of class Key at: assetAdministrationShells/*[0]/derivedFrom/keys/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/langString/language.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/langString/language.xml.exception
@@ -1,1 +1,1 @@
-The required property Language has not been given in the XML representation of an instance of class LangString at: *[0]/*[0]
+The required property Language has not been given in the XML representation of an instance of class LangString at: assetAdministrationShells/*[0]/displayName/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/langString/text.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/langString/text.xml.exception
@@ -1,1 +1,1 @@
-The required property Text has not been given in the XML representation of an instance of class LangString at: *[0]/*[0]
+The required property Text has not been given in the XML representation of an instance of class LangString at: assetAdministrationShells/*[0]/displayName/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/operationVariable/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/operationVariable/value.xml.exception
@@ -1,1 +1,1 @@
-The required property Value has not been given in the XML representation of an instance of class OperationVariable at: *[0]/*[0]/*[0]
+The required property Value has not been given in the XML representation of an instance of class OperationVariable at: submodels/*[0]/submodelElements/*[0]/inputVariables/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/property/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/property/valueType.xml.exception
@@ -1,1 +1,1 @@
-The required property ValueType has not been given in the XML representation of an instance of class Property at: *[0]/*[0]
+The required property ValueType has not been given in the XML representation of an instance of class Property at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/qualifier/type.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/qualifier/type.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Qualifier at: *[0]/*[0]
+The required property Type has not been given in the XML representation of an instance of class Qualifier at: submodels/*[0]/qualifiers/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/qualifier/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/qualifier/valueType.xml.exception
@@ -1,1 +1,1 @@
-The required property ValueType has not been given in the XML representation of an instance of class Qualifier at: *[0]/*[0]
+The required property ValueType has not been given in the XML representation of an instance of class Qualifier at: submodels/*[0]/qualifiers/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/range/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/range/valueType.xml.exception
@@ -1,1 +1,1 @@
-The required property ValueType has not been given in the XML representation of an instance of class Range at: *[0]/*[0]
+The required property ValueType has not been given in the XML representation of an instance of class Range at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/keys.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/keys.xml.exception
@@ -1,1 +1,1 @@
-The required property Keys has not been given in the XML representation of an instance of class Reference at: *[0]/semanticId
+The required property Keys has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/type.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/type.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/relationshipElement/first.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/relationshipElement/first.xml.exception
@@ -1,1 +1,1 @@
-The required property First has not been given in the XML representation of an instance of class RelationshipElement at: *[0]/*[0]
+The required property First has not been given in the XML representation of an instance of class RelationshipElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/relationshipElement/second.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/relationshipElement/second.xml.exception
@@ -1,1 +1,1 @@
-The required property Second has not been given in the XML representation of an instance of class RelationshipElement at: *[0]/*[0]
+The required property Second has not been given in the XML representation of an instance of class RelationshipElement at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/resource/path.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/resource/path.xml.exception
@@ -1,1 +1,1 @@
-The required property Path has not been given in the XML representation of an instance of class Resource at: *[0]/assetInformation/defaultThumbnail
+The required property Path has not been given in the XML representation of an instance of class Resource at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/specificAssetId/externalSubjectId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/specificAssetId/externalSubjectId.xml.exception
@@ -1,1 +1,1 @@
-The required property ExternalSubjectId has not been given in the XML representation of an instance of class SpecificAssetId at: *[0]/assetInformation/*[0]
+The required property ExternalSubjectId has not been given in the XML representation of an instance of class SpecificAssetId at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/specificAssetId/name.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/specificAssetId/name.xml.exception
@@ -1,1 +1,1 @@
-The required property Name has not been given in the XML representation of an instance of class SpecificAssetId at: *[0]/assetInformation/*[0]
+The required property Name has not been given in the XML representation of an instance of class SpecificAssetId at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/specificAssetId/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/specificAssetId/value.xml.exception
@@ -1,1 +1,1 @@
-The required property Value has not been given in the XML representation of an instance of class SpecificAssetId at: *[0]/assetInformation/*[0]
+The required property Value has not been given in the XML representation of an instance of class SpecificAssetId at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/submodel/id.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/submodel/id.xml.exception
@@ -1,1 +1,1 @@
-The required property Id has not been given in the XML representation of an instance of class Submodel at: *[0]
+The required property Id has not been given in the XML representation of an instance of class Submodel at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/submodelElementList/typeValueListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/submodelElementList/typeValueListElement.xml.exception
@@ -1,1 +1,1 @@
-The required property TypeValueListElement has not been given in the XML representation of an instance of class SubmodelElementList at: *[0]/*[0]
+The required property TypeValueListElement has not been given in the XML representation of an instance of class SubmodelElementList at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/valueList/valueReferencePairs.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/valueList/valueReferencePairs.xml.exception
@@ -1,1 +1,1 @@
-The required property ValueReferencePairs has not been given in the XML representation of an instance of class ValueList at: *[0]/*[0]/dataSpecificationContent/valueList
+The required property ValueReferencePairs has not been given in the XML representation of an instance of class ValueList at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/valueReferencePair/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/valueReferencePair/value.xml.exception
@@ -1,1 +1,1 @@
-The required property Value has not been given in the XML representation of an instance of class ValueReferencePair at: *[0]/*[0]/dataSpecificationContent/valueList/*[0]
+The required property Value has not been given in the XML representation of an instance of class ValueReferencePair at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/valueReferencePair/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/valueReferencePair/valueId.xml.exception
@@ -1,1 +1,1 @@
-The required property ValueId has not been given in the XML representation of an instance of class ValueReferencePair at: *[0]/*[0]/dataSpecificationContent/valueList/*[0]
+The required property ValueId has not been given in the XML representation of an instance of class ValueReferencePair at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AdministrativeInformation with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/administration
+Expected an XML end element to conclude a property of class AdministrativeInformation with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/administration

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/revision.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/revision.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AdministrativeInformation with the element name revision, but got the node of type Element with the value  at: *[0]/administration
+Expected an XML end element to conclude a property of class AdministrativeInformation with the element name revision, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/administration

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/version.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/version.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AdministrativeInformation with the element name version, but got the node of type Element with the value  at: *[0]/administration
+Expected an XML end element to conclude a property of class AdministrativeInformation with the element name version, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/administration

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/annotations.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/annotations.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name annotations, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name annotations, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/first
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/first

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class AnnotatedRelationshipElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class AnnotatedRelationshipElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/second
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/second

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class AnnotatedRelationshipElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name administration, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name administration, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml.exception
@@ -1,1 +1,1 @@
-The required property AssetKind has not been given in the XML representation of an instance of class AssetInformation at: *[0]/assetInformation
+The required property AssetKind has not been given in the XML representation of an instance of class AssetInformation at: assetAdministrationShells/*[0]/assetInformation

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name category, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name category, but got the node of type Element with the value  at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name checksum, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name checksum, but got the node of type Element with the value  at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/derivedFrom
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/derivedFrom

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name description, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name displayName, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name extensions, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/id.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/id.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name id, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name id, but got the node of type Element with the value  at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name idShort, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name idShort, but got the node of type Element with the value  at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/submodels.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/submodels.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name submodels, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name submodels, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml.exception
@@ -1,1 +1,1 @@
-The property AssetKind of an instance of class AssetInformation could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/assetInformation/assetKind
+The property AssetKind of an instance of class AssetInformation could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: assetAdministrationShells/*[0]/assetInformation/assetKind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml.exception
@@ -1,1 +1,1 @@
-The required property Path has not been given in the XML representation of an instance of class Resource at: *[0]/assetInformation/defaultThumbnail
+The required property Path has not been given in the XML representation of an instance of class Resource at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/globalAssetId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/globalAssetId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/assetInformation/globalAssetId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/assetInformation/globalAssetId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/specificAssetIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/specificAssetIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class AssetInformation with the element name specificAssetIds, but got the node of type Text with the value Unexpected string value at: *[0]/assetInformation
+Expected an XML end element to conclude a property of class AssetInformation with the element name specificAssetIds, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/assetInformation

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml.exception
@@ -1,1 +1,1 @@
-The property Direction of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/direction
+The property Direction of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/direction

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/lastUpdate.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/lastUpdate.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name lastUpdate, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name lastUpdate, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/maxInterval.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/maxInterval.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name maxInterval, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name maxInterval, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/messageBroker
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/messageBroker

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageTopic.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageTopic.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name messageTopic, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name messageTopic, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/minInterval.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/minInterval.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name minInterval, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name minInterval, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/observed
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/observed

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml.exception
@@ -1,1 +1,1 @@
-The property State of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/state
+The property State of an instance of class BasicEventElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/state

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class BasicEventElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class BasicEventElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/contentType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/contentType.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name contentType, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name contentType, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Blob could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Blob could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Blob with the element name value, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Blob with the element name value, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Capability could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Capability could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Capability with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Capability with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name administration, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name administration, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name category, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name category, but got the node of type Element with the value  at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name checksum, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name checksum, but got the node of type Element with the value  at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name description, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name displayName, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name extensions, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/id.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/id.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name id, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name id, but got the node of type Element with the value  at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name idShort, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name idShort, but got the node of type Element with the value  at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/isCaseOf.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/isCaseOf.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ConceptDescription with the element name isCaseOf, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class ConceptDescription with the element name isCaseOf, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml.exception
@@ -1,1 +1,1 @@
-The property DataType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/dataSpecificationContent/dataType
+The property DataType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/dataType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/definition.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/definition.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name definition, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name definition, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml.exception
@@ -1,1 +1,1 @@
-The property LevelType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/dataSpecificationContent/levelType
+The property LevelType of an instance of class DataSpecificationIec61360 could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/levelType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/preferredName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/preferredName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name preferredName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name preferredName, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/shortName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/shortName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name shortName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name shortName, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/sourceOfDefinition.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/sourceOfDefinition.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name sourceOfDefinition, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name sourceOfDefinition, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/symbol.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/symbol.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name symbol, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name symbol, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unit.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unit.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name unit, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name unit, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/dataSpecificationContent/unitId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/unitId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name value, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name value, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/valueFormat.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/valueFormat.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name valueFormat, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationIec61360 with the element name valueFormat, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/valueList.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/valueList.xml.exception
@@ -1,1 +1,1 @@
-The required property ValueReferencePairs has not been given in the XML representation of an instance of class ValueList at: *[0]/*[0]/dataSpecificationContent/valueList
+The required property ValueReferencePairs has not been given in the XML representation of an instance of class ValueList at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/conversionFactor.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/conversionFactor.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name conversionFactor, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name conversionFactor, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/definition.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/definition.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name definition, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name definition, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/dinNotation.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/dinNotation.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name dinNotation, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name dinNotation, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/eceCode.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/eceCode.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name eceCode, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name eceCode, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/eceName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/eceName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name eceName, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name eceName, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/nistName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/nistName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name nistName, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name nistName, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/registrationAuthorityId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/registrationAuthorityId.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name registrationAuthorityId, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name registrationAuthorityId, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/siName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/siName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name siName, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name siName, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/siNotation.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/siNotation.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name siNotation, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name siNotation, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/sourceOfDefinition.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/sourceOfDefinition.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name sourceOfDefinition, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name sourceOfDefinition, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/supplier.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/supplier.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name supplier, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name supplier, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/unitName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/unitName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name unitName, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name unitName, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/unitSymbol.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationPhysicalUnit/unitSymbol.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name unitSymbol, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent
+Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit with the element name unitSymbol, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/dataSpecification
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecification

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML element, but got a node of type Text with value Unexpected string value at: *[0]/*[0]/dataSpecificationContent
+Expected an XML element, but got a node of type Text with value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml.exception
@@ -1,1 +1,1 @@
-The property EntityType of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/entityType
+The property EntityType of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/entityType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/globalAssetId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/globalAssetId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/globalAssetId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/globalAssetId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Entity could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/specificAssetId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/specificAssetId.xml.exception
@@ -1,1 +1,1 @@
-The required property Name has not been given in the XML representation of an instance of class SpecificAssetId at: *[0]/*[0]/specificAssetId
+The required property Name has not been given in the XML representation of an instance of class SpecificAssetId at: submodels/*[0]/submodelElements/*[0]/specificAssetId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/statements.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/statements.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name statements, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name statements, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Entity with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Entity with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/name.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/name.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Extension with the element name name, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Extension with the element name name, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/extensions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/refersTo.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/refersTo.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/refersTo
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/extensions/*[0]/refersTo

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/extensions/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Extension with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Extension with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/extensions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Extension with the element name value, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Extension with the element name value, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/extensions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Extension could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Extension could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: assetAdministrationShells/*[0]/extensions/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/contentType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/contentType.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name contentType, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name contentType, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class File could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class File could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class File with the element name value, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class File with the element name value, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml.exception
@@ -1,1 +1,1 @@
-The property Type of an instance of class Key could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/derivedFrom/*[0]/type
+The property Type of an instance of class Key could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: assetAdministrationShells/*[0]/derivedFrom/keys/*[0]/type

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Key with the element name value, but got the node of type Element with the value  at: *[0]/derivedFrom/*[0]
+Expected an XML end element to conclude a property of class Key with the element name value, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/derivedFrom/keys/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langString/language.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langString/language.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class LangString with the element name language, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class LangString with the element name language, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/displayName/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langString/text.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langString/text.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class LangString with the element name text, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class LangString with the element name text, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/displayName/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class MultiLanguageProperty could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class MultiLanguageProperty could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name value, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class MultiLanguageProperty with the element name value, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/inoutputVariables.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/inoutputVariables.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name inoutputVariables, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name inoutputVariables, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/inputVariables.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/inputVariables.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name inputVariables, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name inputVariables, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Operation could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Operation could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/outputVariables.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/outputVariables.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name outputVariables, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name outputVariables, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Operation with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Operation with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML element, but got a node of type Text with value Unexpected string value at: *[0]/*[0]/*[0]/value
+Expected an XML element, but got a node of type Text with value Unexpected string value at: submodels/*[0]/submodelElements/*[0]/inputVariables/*[0]/value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Property could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Property could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Property with the element name value, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Property with the element name value, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Property could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Property could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/qualifiers/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/qualifiers/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Qualifier with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Qualifier with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/qualifiers/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/type.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/type.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Qualifier with the element name type, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Qualifier with the element name type, but got the node of type Element with the value  at: submodels/*[0]/qualifiers/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Qualifier with the element name value, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Qualifier with the element name value, but got the node of type Element with the value  at: submodels/*[0]/qualifiers/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/qualifiers/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Qualifier could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/qualifiers/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Range could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class Range could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/max.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/max.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name max, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name max, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/min.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/min.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name min, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name min, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Range with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class Range with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml.exception
@@ -1,1 +1,1 @@
-The property ValueType of an instance of class Range could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/valueType
+The property ValueType of an instance of class Range could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/valueType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/keys.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/keys.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Reference with the element name keys, but got the node of type Text with the value Unexpected string value at: *[0]/semanticId
+Expected an XML end element to conclude a property of class Reference with the element name keys, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/semanticId/referredSemanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/semanticId/referredSemanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml.exception
@@ -1,1 +1,1 @@
-The property Type of an instance of class Reference could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/semanticId/type
+The property Type of an instance of class Reference could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/semanticId/type

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class ReferenceElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class ReferenceElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ReferenceElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class ReferenceElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/value
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/first
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/first

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class RelationshipElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class RelationshipElement could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/second
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/second

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class RelationshipElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class RelationshipElement with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/contentType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/contentType.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Resource with the element name contentType, but got the node of type Element with the value  at: *[0]/assetInformation/defaultThumbnail
+Expected an XML end element to conclude a property of class Resource with the element name contentType, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/path.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/path.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Resource with the element name path, but got the node of type Element with the value  at: *[0]/assetInformation/defaultThumbnail
+Expected an XML end element to conclude a property of class Resource with the element name path, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/assetInformation/*[0]/externalSubjectId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]/externalSubjectId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/name.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/name.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SpecificAssetId with the element name name, but got the node of type Element with the value  at: *[0]/assetInformation/*[0]
+Expected an XML end element to conclude a property of class SpecificAssetId with the element name name, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/assetInformation/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SpecificAssetId with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/assetInformation/*[0]
+Expected an XML end element to conclude a property of class SpecificAssetId with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SpecificAssetId with the element name value, but got the node of type Element with the value  at: *[0]/assetInformation/*[0]
+Expected an XML end element to conclude a property of class SpecificAssetId with the element name value, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name administration, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name administration, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name category, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name category, but got the node of type Element with the value  at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name checksum, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/id.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/id.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name id, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name id, but got the node of type Element with the value  at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name idShort, but got the node of type Element with the value  at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class Submodel could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/kind
+The property Kind of an instance of class Submodel could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/submodelElements.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/submodelElements.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name submodelElements, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name submodelElements, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Submodel with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]
+Expected an XML end element to conclude a property of class Submodel with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class SubmodelElementCollection could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class SubmodelElementCollection could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name value, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementCollection with the element name value, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/category.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/category.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name category, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name category, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/checksum.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/checksum.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name checksum, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name checksum, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/description.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/description.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name description, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name description, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/displayName.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/displayName.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name displayName, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name displayName, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/embeddedDataSpecifications.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/embeddedDataSpecifications.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name embeddedDataSpecifications, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/extensions.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/extensions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name extensions, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name extensions, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/idShort.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/idShort.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name idShort, but got the node of type Element with the value  at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name idShort, but got the node of type Element with the value  at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/kind.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/kind.xml.exception
@@ -1,1 +1,1 @@
-The property Kind of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/kind
+The property Kind of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/kind

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/orderRelevant.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/orderRelevant.xml.exception
@@ -1,1 +1,1 @@
-The property OrderRelevant of an instance of class SubmodelElementList could not be de-serialized: Content cannot be converted to the type Boolean. Line 80, position 8. at: *[0]/*[0]/orderRelevant
+The property OrderRelevant of an instance of class SubmodelElementList could not be de-serialized: Content cannot be converted to the type Boolean. Line 80, position 8. at: submodels/*[0]/submodelElements/*[0]/orderRelevant

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/qualifiers.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/qualifiers.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name qualifiers, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/semanticIdListElement
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticIdListElement

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/supplementalSemanticIds.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/supplementalSemanticIds.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name supplementalSemanticIds, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml.exception
@@ -1,1 +1,1 @@
-The property TypeValueListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/typeValueListElement
+The property TypeValueListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/typeValueListElement

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class SubmodelElementList with the element name value, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]
+Expected an XML end element to conclude a property of class SubmodelElementList with the element name value, but got the node of type Text with the value Unexpected string value at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml.exception
@@ -1,1 +1,1 @@
-The property ValueTypeListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: *[0]/*[0]/valueTypeListElement
+The property ValueTypeListElement of an instance of class SubmodelElementList could not be de-serialized from an unexpected enumeration literal: Unexpected string value at: submodels/*[0]/submodelElements/*[0]/valueTypeListElement

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueList/valueReferencePairs.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueList/valueReferencePairs.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ValueList with the element name valueReferencePairs, but got the node of type Text with the value Unexpected string value at: *[0]/*[0]/dataSpecificationContent/valueList
+Expected an XML end element to conclude a property of class ValueList with the element name valueReferencePairs, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/value.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class ValueReferencePair with the element name value, but got the node of type Element with the value  at: *[0]/*[0]/dataSpecificationContent/valueList/*[0]
+Expected an XML end element to conclude a property of class ValueReferencePair with the element name value, but got the node of type Element with the value  at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml.exception
@@ -1,1 +1,1 @@
-The required property Type has not been given in the XML representation of an instance of class Reference at: *[0]/*[0]/dataSpecificationContent/valueList/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/administrativeInformation/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/administrativeInformation/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AdministrativeInformation, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/administration
+We expected properties of the class AdministrativeInformation, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/administration

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/annotatedRelationshipElement/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/annotatedRelationshipElement/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AnnotatedRelationshipElement, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class AnnotatedRelationshipElement, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/assetAdministrationShell/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/assetAdministrationShell/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AssetAdministrationShell, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]
+We expected properties of the class AssetAdministrationShell, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/assetInformation/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/assetInformation/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AssetInformation, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/assetInformation
+We expected properties of the class AssetInformation, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/assetInformation

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/basicEventElement/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/basicEventElement/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class BasicEventElement, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class BasicEventElement, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/blob/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/blob/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Blob, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Blob, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/capability/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/capability/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Capability, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Capability, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/conceptDescription/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/conceptDescription/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class ConceptDescription, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]
+We expected properties of the class ConceptDescription, but got an unexpected element with the name unexpectedAdditionalProperty at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/dataSpecificationIec61360/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/dataSpecificationIec61360/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class DataSpecificationIec61360, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]/dataSpecificationContent
+We expected properties of the class DataSpecificationIec61360, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/dataSpecificationPhysicalUnit/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/dataSpecificationPhysicalUnit/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class DataSpecificationPhysicalUnit, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]/dataSpecificationContent
+We expected properties of the class DataSpecificationPhysicalUnit, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationPhysicalUnit

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/embeddedDataSpecification/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/embeddedDataSpecification/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class EmbeddedDataSpecification, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class EmbeddedDataSpecification, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/entity/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/entity/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Entity, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Entity, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/extension/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/extension/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Extension, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Extension, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/extensions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/file/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/file/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class File, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class File, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/key/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/key/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Key, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/derivedFrom/*[0]
+We expected properties of the class Key, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/derivedFrom/keys/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/langString/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/langString/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class LangString, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class LangString, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/displayName/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/multiLanguageProperty/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/multiLanguageProperty/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class MultiLanguageProperty, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class MultiLanguageProperty, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/operation/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/operation/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Operation, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Operation, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/operationVariable/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/operationVariable/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class OperationVariable, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]/*[0]
+We expected properties of the class OperationVariable, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]/inputVariables/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/property/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/property/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Property, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Property, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/qualifier/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/qualifier/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Qualifier, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Qualifier, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/qualifiers/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/range/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/range/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Range, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class Range, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/reference/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/reference/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/semanticId
+We expected properties of the class Reference, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/referenceElement/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/referenceElement/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class ReferenceElement, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class ReferenceElement, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/relationshipElement/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/relationshipElement/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class RelationshipElement, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class RelationshipElement, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/resource/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/resource/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Resource, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/assetInformation/defaultThumbnail
+We expected properties of the class Resource, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/specificAssetId/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/specificAssetId/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class SpecificAssetId, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/assetInformation/*[0]
+We expected properties of the class SpecificAssetId, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/submodel/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/submodel/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Submodel, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]
+We expected properties of the class Submodel, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/submodelElementCollection/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/submodelElementCollection/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class SubmodelElementCollection, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class SubmodelElementCollection, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/submodelElementList/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/submodelElementList/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class SubmodelElementList, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]
+We expected properties of the class SubmodelElementList, but got an unexpected element with the name unexpectedAdditionalProperty at: submodels/*[0]/submodelElements/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/valueList/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/valueList/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class ValueList, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]/dataSpecificationContent/valueList
+We expected properties of the class ValueList, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/valueReferencePair/invalid.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/valueReferencePair/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class ValueReferencePair, but got an unexpected element with the name unexpectedAdditionalProperty at: *[0]/*[0]/dataSpecificationContent/valueList/*[0]
+We expected properties of the class ValueReferencePair, but got an unexpected element with the name unexpectedAdditionalProperty at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]


### PR DESCRIPTION
We did not produce the correct XPaths in xmlization exceptions, but this went unnoticed as the current XPaths resembled the correct ones.

This patch prepends the necessary element names, so that now the exceptions can be correctly traced in the problematic XML documents.

Fixes #68.