### PR TITLE
Fix date verification of BCE and zero years in C#

### DIFF
--- a/src/AasCore.Aas3_0_RC02/verification.cs
+++ b/src/AasCore.Aas3_0_RC02/verification.cs
@@ -97,47 +97,159 @@ namespace AasCore.Aas3_0_RC02
             return RegexMatchesXsDateTimeStampUtc.IsMatch(text);
         }
 
-        private static readonly string[] XsDateFormats = {
-            "yyyy-MM-dd"
-        };
+        private static readonly Regex RegexDatePrefix = (
+            new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})"));
 
         /// <summary>
-        /// Clip the <paramref name="value" /> to the date part.
+        /// Check whether the given year is a leap year.
         /// </summary>
-        /// <remarks>
-        /// We ignore the negative sign prefix and clip years to 4 digits.
-        /// This is necessary as <see cref="System.DateTime" /> can not handle
-        /// dates B.C. and the <see cref="o:System.DateTime.ParseExact" /> expects
-        /// exactly four digits.
-        ///
-        /// We strip the negative sign and assume astronomical years.
-        /// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm and
-        /// the note at: https://www.w3.org/TR/xmlschema-2/#dateTime
-        ///
-        /// Furthermore, we always assume that <paramref name="value" /> has been
-        /// already validated with the corresponding regular expression.
-        /// Hence we can use this function to validate the date-times as the time
-        /// segment and offsets are correctly matched by the regular expression,
-        /// while day/month combinations need to be validated by
-        /// <see cref="o:System.DateTime.ParseExact" />.
-        /// </remarks>
-        private static string ClipToDate(string value)
+        /// <remarks>Year 1 BCE is a leap year.</remarks>
+        /// <param name="year">to be checked</param>
+        /// <returns>True if <paramref name="year"/> is a leap year</returns>
+        public static bool IsLeapYear(System.Numerics.BigInteger year)
         {
-            int start = 0;
-            if (value[0] == '-')
+            // NOTE (mristin, 2022-11-02):
+            // We consider the years B.C. to be one-off.
+            // See the note at: https://www.w3.org/TR/xmlschema-2/#dateTime:
+            // "'-0001' is the lexical representation of the year 1 Before Common Era
+            // (1 BCE, sometimes written "1 BC")."
+            //
+            // Hence, -1 year in XML is 1 BCE, which is 0 year in astronomical years.
+            if (year < 0)
             {
-                start++;
+                year = -year - 1;
             }
 
-            int yearEnd = start;
-            for (; value[yearEnd] != '-'; yearEnd++)
+            // See: See: https://en.wikipedia.org/wiki/Leap_year#Algorithm
+            if (year % 4 > 0)
             {
-                // Intentionally empty.
+                return false;
             }
 
-            return (yearEnd == 4 && value.Length == 10)
-                ? value
-                : value.Substring(yearEnd - 4, 10);
+            if (year % 100 > 0)
+            {
+                return true;
+            }
+
+            if (year % 400 > 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Check that the value starts with a valid date.
+        /// </summary>
+        /// <param name="value">
+        ///     an <c>xs:date</c>, an <c>xs:dateTime</c>,
+        ///     or an <c>xs:dateTimeStamp</c></param>
+        /// <returns>
+        ///     <c>true</c> if the value starts with a valid date
+        /// </returns>
+        private static bool IsPrefixedWithValidDate(string value)
+        {
+            // NOTE (mristin, 2022-11-02):
+            // We can not use System.DateTime.ParseExact since it does not handle the zero and
+            // BCE years correctly. Therefore, we have to roll out our own date validator.
+            var match = RegexDatePrefix.Match(value);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            bool ok = System.Numerics.BigInteger.TryParse(
+                match.Groups[1].Value,
+                out System.Numerics.BigInteger year);
+            if (!ok)
+            {
+                throw new System.InvalidOperationException(
+                    $"Expected to parse the year from {match.Groups[1].Value}, " +
+                    "but the parsing failed");
+            }
+
+            ok = System.SByte.TryParse(match.Groups[2].Value, out sbyte month);
+            if (!ok)
+            {
+                throw new System.InvalidOperationException(
+                    $"Expected to parse the month from {match.Groups[2].Value}, " +
+                    "but the parsing failed");
+            }
+
+            ok = System.SByte.TryParse(match.Groups[3].Value, out sbyte day);
+            if (!ok)
+            {
+                throw new System.InvalidOperationException(
+                    $"Expected to parse the day from {match.Groups[3].Value}, " +
+                    "but the parsing failed");
+            }
+
+            // Year zero does not exist, see: https://www.w3.org/TR/xmlschema-2/#dateTime
+            if (year == 0)
+            {
+                return false;
+            }
+
+            if (day <= 0 || day > 31)
+            {
+                return false;
+            }
+
+            if (month <= 0 || month >= 13)
+            {
+                return false;
+            }
+
+            sbyte maxDaysInMonth;
+            switch (month)
+            {
+                case 1:
+                    maxDaysInMonth = 31;
+                    break;
+                case 2:
+                    maxDaysInMonth = (IsLeapYear(year)) ? (sbyte)29 : (sbyte)28;
+                    break;
+                case 3:
+                    maxDaysInMonth = 31;
+                    break;
+                case 4:
+                    maxDaysInMonth = 30;
+                    break;
+                case 5:
+                    maxDaysInMonth = 31;
+                    break;
+                case 6:
+                    maxDaysInMonth = 30;
+                    break;
+                case 7:
+                    maxDaysInMonth = 31;
+                    break;
+                case 8:
+                    maxDaysInMonth = 31;
+                    break;
+                case 9:
+                    maxDaysInMonth = 30;
+                    break;
+                case 10:
+                    maxDaysInMonth = 31;
+                    break;
+                case 11:
+                    maxDaysInMonth = 30;
+                    break;
+                case 12:
+                    maxDaysInMonth = 31;
+                    break;
+                default:
+                    throw new System.InvalidOperationException($"Unexpected month: {month}");
+            }
+
+            if (day > maxDaysInMonth)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -153,20 +265,7 @@ namespace AasCore.Aas3_0_RC02
                 return false;
             }
 
-            try
-            {
-                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                System.DateTime.ParseExact(
-                    ClipToDate(value),
-                    XsDateFormats,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    System.Globalization.DateTimeStyles.None);
-                return true;
-            }
-            catch (System.FormatException)
-            {
-                return false;
-            }
+            return IsPrefixedWithValidDate(value);
         }
 
         [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -1434,20 +1533,7 @@ namespace AasCore.Aas3_0_RC02
                             return false;
                         }
 
-                        try
-                        {
-                            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                            System.DateTime.ParseExact(
-                                ClipToDate(value),
-                                XsDateFormats,
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                System.Globalization.DateTimeStyles.None);
-                            return true;
-                        }
-                        catch (System.FormatException)
-                        {
-                            return false;
-                        }
+                        return IsPrefixedWithValidDate(value);
                     }
                 case Aas.DataTypeDefXsd.DateTime:
                     {
@@ -1459,21 +1545,7 @@ namespace AasCore.Aas3_0_RC02
                         // The time part and the time zone part will be checked by
                         // MatchesXsDateTime. We need to check that the date part is
                         // correct in sense of the day/month combination.
-
-                        try
-                        {
-                            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                            System.DateTime.ParseExact(
-                                ClipToDate(value),
-                                XsDateFormats,
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                System.Globalization.DateTimeStyles.None);
-                            return true;
-                        }
-                        catch (System.FormatException)
-                        {
-                            return false;
-                        }
+                        return IsPrefixedWithValidDate(value);
                     }
                 case Aas.DataTypeDefXsd.DateTimeStamp:
                     {
@@ -1485,21 +1557,7 @@ namespace AasCore.Aas3_0_RC02
                         // The time part and the time zone part will be checked by
                         // MatchesXsDateTimeStamp. We need to check that the date part is
                         // correct in sense of the day/month combination.
-
-                        try
-                        {
-                            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                            System.DateTime.ParseExact(
-                                ClipToDate(value),
-                                XsDateFormats,
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                System.Globalization.DateTimeStyles.None);
-                            return true;
-                        }
-                        catch (System.FormatException)
-                        {
-                            return false;
-                        }
+                        return IsPrefixedWithValidDate(value);
                     }
                 case Aas.DataTypeDefXsd.Decimal:
                     {

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29",
+          "min": "-0001-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29",
+          "min": "-0005-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29T01:02:03",
+          "min": "-0001-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29T01:02:03",
+          "min": "-0005-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29T01:02:03Z",
+          "min": "-0001-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29T01:02:03Z",
+          "min": "-0005-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29",
+          "min": "-0004-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02",
+          "min": "0000-01-02",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29T01:02:03",
+          "min": "-0004-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02T01:02:03",
+          "min": "0000-01-02T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29T01:02:03Z",
+          "min": "-0004-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02T01:02:03Z",
+          "min": "0000-01-02T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0001-02-29</min>
+					<max>-0001-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0005-02-29</min>
+					<max>-0005-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0001-02-29T01:02:03</min>
+					<max>-0001-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0005-02-29T01:02:03</min>
+					<max>-0005-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0001-02-29T01:02:03Z</min>
+					<max>-0001-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0005-02-29T01:02:03Z</min>
+					<max>-0005-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0004-02-29</min>
+					<max>-0004-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>0000-01-02</min>
+					<max>0000-01-02</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0004-02-29T01:02:03</min>
+					<max>-0004-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>0000-01-02T01:02:03</min>
+					<max>0000-01-02T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0004-02-29T01:02:03Z</min>
+					<max>-0004-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>0000-01-02T01:02:03Z</min>
+					<max>0000-01-02T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,4 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Max must be consistent with the value type.;
+submodels[0].submodelElements[0]: Invariant violated:
+Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+assetAdministrationShells[0].extensions[0]: Invariant violated:
+The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].submodelElements[0]: Invariant violated:
+Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+submodels[0].qualifiers[0]: Invariant violated:
+Constraint AASd-020: The value shall be consistent to the data type as defined in value type.


### PR DESCRIPTION
We explicitly tested for zero and BCE years in [aas-core3.0rc02-testgen eeba8f71] which revealed that the C# SDK did not handle those edge cases correctly.

In this patch, we re-generate the code using [aas-core-codegen 4c671254], and fix the verification of dates BCE and with zero years.

[aas-core3.0rc02-testgen eeba8f71]: https://github.com/aas-core-works/aas-core3.0rc02-testgen/commit/eeba8f71
[aas-core-codegen 4c671254]: https://github.com/aas-core-works/aas-core-codegen/commit/4c671254