### PR TITLE
Fix docs for XML serialization

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="83706ea3-1c99-49d2-8237-0e5982ac8a2f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/xmlization.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/xmlization.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/AasCore.Aas3_0_RC02/xmlization.cs
+++ b/src/AasCore.Aas3_0_RC02/xmlization.cs
@@ -26037,21 +26037,6 @@ namespace AasCore.Aas3_0_RC02
         ///     anInstance,
         ///     writer);
         /// </code>
-        ///
-        /// </example>
-        /// <example>
-        /// You can also set the namespace and the prefix:
-        /// <code>
-        /// var anInstance = new Aas.IHasSemantics(
-        ///     /* ... some constructor arguments ... */
-        /// );
-        /// var writer = new System.Xml.XmlWriter( /* some arguments */ );
-        /// Serialize.To(
-        ///     anInstance,
-        ///     writer,
-        ///     "somePrefix",
-        ///     "https://some-namespace.com");
-        /// </code>
         /// </example>
         public static class Serialize
         {


### PR DESCRIPTION
The documentation for XML serialization has been outdated. It still listed the namespace and the prefix argument from the original design which has been removed in the meanwhile.

This patch synchronizes the documentation with the code.

We used [aas-core-codegen 6458aee4] to generate the code.

[aas-core-codegen 6458aee4]: https://github.com/aas-core-works/aas-core-codegen/commit/6458aee4