### PR TITLE
Exclude inherited properties in interfaces

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -39,7 +39,7 @@
     ]
   }
 }</component>
-  <component name="RunManager" selected="Python.generate_test_for_copying">
+  <component name="RunManager" selected="Python.generate_all">
     <configuration name="generate_all" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="aas-core3.0rc02-csharp" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -84,8 +84,8 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Python.generate_test_for_copying" />
         <item itemvalue="Python.generate_all" />
+        <item itemvalue="Python.generate_test_for_copying" />
       </list>
     </recent_temporary>
   </component>

--- a/src/AasCore.Aas3_0_RC02/types.cs
+++ b/src/AasCore.Aas3_0_RC02/types.cs
@@ -4005,30 +4005,6 @@ namespace AasCore.Aas3_0_RC02
     public interface IDataElement : ISubmodelElement
     {
         public string CategoryOrDefault();
-        /// <summary>
-        /// Iterate over Extensions, if set, and otherwise return an empty enumerable.
-        /// </summary>
-        public IEnumerable<Extension> OverExtensionsOrEmpty();
-        /// <summary>
-        /// Iterate over DisplayName, if set, and otherwise return an empty enumerable.
-        /// </summary>
-        public IEnumerable<LangString> OverDisplayNameOrEmpty();
-        /// <summary>
-        /// Iterate over Description, if set, and otherwise return an empty enumerable.
-        /// </summary>
-        public IEnumerable<LangString> OverDescriptionOrEmpty();
-        /// <summary>
-        /// Iterate over SupplementalSemanticIds, if set, and otherwise return an empty enumerable.
-        /// </summary>
-        public IEnumerable<Reference> OverSupplementalSemanticIdsOrEmpty();
-        /// <summary>
-        /// Iterate over Qualifiers, if set, and otherwise return an empty enumerable.
-        /// </summary>
-        public IEnumerable<Qualifier> OverQualifiersOrEmpty();
-        /// <summary>
-        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
-        /// </summary>
-        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty();
     }
 
     /// <summary>

--- a/testgen/requirements.txt
+++ b/testgen/requirements.txt
@@ -1,2 +1,2 @@
 aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e3707bf#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@46ddb38f#egg=aas-core-codegen
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@c8919e7#egg=aas-core-codegen


### PR DESCRIPTION
We only list the properties in interfaces defined in the related abstract class of the meta-model. Previously, we included *all* the properties (including the inherited ones) which was unnecessary as interfaces inherit properties from their parents.

This change corresponds to [aas-core-codegen c8919e77].

[aas-core-codegen c8919e77]: https://github.com/aas-core-works/aas-core-codegen/commit/c8919e77