### PR TITLE
Allow for selective enhancement

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="83706ea3-1c99-49d2-8237-0e5982ac8a2f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/AasCore.Aas3_0_RC02.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/src/AasCore.Aas3_0_RC02/AasCore.Aas3_0_RC02.csproj" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/doc/source/getting_started/enhancing.md
+++ b/doc/source/getting_started/enhancing.md
@@ -4,7 +4,10 @@ In any complex application, creating, modifying and de/serializing AAS instances
 You have to insert your custom application-specific data to the model in order for the model to be useful.
 
 Take, for example, parent-child relationship.
-The current library ignores it, and there is no easy way for you to find out to which [Submodel] a particular [SubmodelElement] belongs to.
+The current library ignores it, and there is no easy way for you to find out to which [Submodel] a particular [ISubmodelElement] belongs to.
+
+[Submodel]: ../api/AasCore.Aas3_0_RC02.Submodel.yml
+[ISubmodelElement]: ../api/AasCore.Aas3_0_RC02.ISubmodelElement.yml
 
 We did want to keep the types as simple as possible — the parent-child relationships can get tricky very soon if you have multiple environments with shared submodels *etc.*
 Instead of overcomplicating the code and making it barely traceable, we decided to keep it simple and frugal in features.
@@ -45,7 +48,7 @@ We call this an *enhancement factory*.
 Second, you need to recursively wrap your instances with the given enhancement factory.
 
 The [Enhancing] is generic and can work with any form of enhancement classes.
-You need to specify your enhancement factory as a [function delegate] which takes [IClass] as input and returns an enhancement.
+You need to specify your enhancement factory as a [function delegate] which takes an instance of [IClass] as input and returns an enhancement, or `null`, if you do not want to enhance the particular instance.
 
 [function delegate]: https://learn.microsoft.com/en-us/dotnet/api/system.func-2
 [IClass]: ../api/AasCore.Aas3_0_RC02.IClass.yml
@@ -141,6 +144,109 @@ public class Program
 Note that this approach is indeed more maintainable than the one with [Hashtable], but you still need to take extra care.
 If you create new submodels and insert them into the environment, you have to make sure that you wrap them appropriately.
 If you move a submodel from one environment to another, you have to update the parent link manually *etc.*
+
+## Example: Selective Enhancement
+
+We demonstrate now how you can selectively enhance only some instances in the [Environment].
+
+For example, let us assign a unique identifier to all instances which are referable, *i.e.*, implement [IReferable].
+All the other instances are not enhanced.
+
+[IReferable]: ../api/AasCore.Aas3_0_RC02.IReferable.yml
+[Environment]: ../api/AasCore.Aas3_0_RC02.Environment.yml
+
+```cs
+using Aas = AasCore.Aas3_0_RC02;
+using AasEnhancing = AasCore.Aas3_0_RC02.Enhancing;
+
+using System.Linq;
+using System.Collections.Generic;
+
+public class Program
+{
+    class IdEnhancement
+    {
+        public long Id;
+
+        public IdEnhancement(long id)
+        {
+            Id = id;
+        }
+    }
+
+    public static void Main()
+    {
+        // Prepare the environment
+        Aas.IEnvironment environment = new Aas.Environment()
+        {
+            Submodels = new List<Aas.ISubmodel>()
+            {
+                new Aas.Submodel(
+                    "some-unique-global-identifier")
+                {
+                    SubmodelElements = new List<Aas.ISubmodelElement>()
+                    {
+                        new Aas.Property(
+                            Aas.DataTypeDefXsd.Boolean)
+                        {
+                            IdShort = "someProperty",
+                        }
+                    },
+                    Administration = new Aas.AdministrativeInformation()
+                    {
+                        Version="1.0"
+                    }
+                }
+            }
+        };
+
+        // Prepare the enhancer
+        long lastId = 0;
+        var enhancementFactory = new System.Func<IClass, IdEnhancement?>(
+            instance =>
+            {
+                if (instance is Aas.IReferable)
+                {
+                    lastId++;
+                    return new IdEnhancement(lastId);
+                }
+
+                return null;
+            }
+        );
+
+        var enhancer = new Aas.Enhancing.Enhancer<IdEnhancement>(
+            enhancementFactory
+        );
+
+        // Enhance
+        environment = (Aas.IEnvironment)enhancer.Wrap(environment);
+
+        // The submodel and property are enhanced.
+        IdEnhancement enhancement = enhancer.MustUnwrap(environment.Submodels![0]);
+        System.Console.WriteLine(enhancement.Id);
+
+        // Prints:
+        // 2
+
+        enhancement = enhancer.MustUnwrap(environment.Submodels![0].SubmodelElements![0]);
+        System.Console.WriteLine(enhancement.Id);
+
+        // Prints:
+        // 1
+
+        // The administrative information is not referable, and thus not enhanced.
+        IdEnhancement? maybeEnhancement = enhancer.Unwrap(
+            environment.Submodels![0].Administration!
+        );
+
+        System.Console.WriteLine(maybeEnhancement == null);
+
+        // Prints:
+        // True
+    }
+}
+```
 
 ## No Re-wraps Allowed
 

--- a/doc/source/toc.yml
+++ b/doc/source/toc.yml
@@ -7,5 +7,5 @@
   href: contributing.md
 - name: Design Decisions
   href: design_decisions.md
-- Name: Change log
+- name: Change log
   href: change_log.md

--- a/src/AasCore.Aas3_0_RC02/enhancing.cs
+++ b/src/AasCore.Aas3_0_RC02/enhancing.cs
@@ -4315,19 +4315,19 @@ namespace AasCore.Aas3_0_RC02
         }
 
         internal class Wrapper<TEnhancement>
-            : Aas.Visitation.AbstractTransformer<Enhanced<TEnhancement>>
+            : Aas.Visitation.AbstractTransformer<Aas.IClass>
             where TEnhancement : class
         {
-            private readonly System.Func<Aas.IClass, TEnhancement> _enhancementFactory;
+            private readonly System.Func<Aas.IClass, TEnhancement?> _enhancementFactory;
 
             internal Wrapper(
-                System.Func<Aas.IClass, TEnhancement> enhancementFactory
+                System.Func<Aas.IClass, TEnhancement?> enhancementFactory
             )
             {
                 _enhancementFactory = enhancementFactory;
             }
 
-            public override Enhanced<TEnhancement> TransformExtension(
+            public override Aas.IClass TransformExtension(
                 Aas.IExtension that
             )
             {
@@ -4385,13 +4385,16 @@ namespace AasCore.Aas3_0_RC02
                     that.RefersTo = castedRefersTo;
                 }
 
-                return new EnhancedExtension<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedExtension<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAdministrativeInformation(
+            public override Aas.IClass TransformAdministrativeInformation(
                 Aas.IAdministrativeInformation that
             )
             {
@@ -4421,13 +4424,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedAdministrativeInformation<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAdministrativeInformation<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformQualifier(
+            public override Aas.IClass TransformQualifier(
                 Aas.IQualifier that
             )
             {
@@ -4485,13 +4491,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId = castedValueId;
                 }
 
-                return new EnhancedQualifier<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedQualifier<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAssetAdministrationShell(
+            public override Aas.IClass TransformAssetAdministrationShell(
                 Aas.IAssetAdministrationShell that
             )
             {
@@ -4636,13 +4645,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedAssetAdministrationShell<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAssetAdministrationShell<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAssetInformation(
+            public override Aas.IClass TransformAssetInformation(
                 Aas.IAssetInformation that
             )
             {
@@ -4700,13 +4712,16 @@ namespace AasCore.Aas3_0_RC02
                     that.DefaultThumbnail = castedDefaultThumbnail;
                 }
 
-                return new EnhancedAssetInformation<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAssetInformation<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformResource(
+            public override Aas.IClass TransformResource(
                 Aas.IResource that
             )
             {
@@ -4717,13 +4732,16 @@ namespace AasCore.Aas3_0_RC02
                     );
                 }
 
-                return new EnhancedResource<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedResource<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSpecificAssetId(
+            public override Aas.IClass TransformSpecificAssetId(
                 Aas.ISpecificAssetId that
             )
             {
@@ -4778,13 +4796,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.ExternalSubjectId = castedExternalSubjectId;
 
-                return new EnhancedSpecificAssetId<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSpecificAssetId<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSubmodel(
+            public override Aas.IClass TransformSubmodel(
                 Aas.ISubmodel that
             )
             {
@@ -4956,13 +4977,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedSubmodel<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSubmodel<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformRelationshipElement(
+            public override Aas.IClass TransformRelationshipElement(
                 Aas.IRelationshipElement that
             )
             {
@@ -5123,13 +5147,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.Second = castedSecond;
 
-                return new EnhancedRelationshipElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedRelationshipElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSubmodelElementList(
+            public override Aas.IClass TransformSubmodelElementList(
                 Aas.ISubmodelElementList that
             )
             {
@@ -5301,13 +5328,16 @@ namespace AasCore.Aas3_0_RC02
                     that.SemanticIdListElement = castedSemanticIdListElement;
                 }
 
-                return new EnhancedSubmodelElementList<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSubmodelElementList<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSubmodelElementCollection(
+            public override Aas.IClass TransformSubmodelElementCollection(
                 Aas.ISubmodelElementCollection that
             )
             {
@@ -5465,13 +5495,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedSubmodelElementCollection<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSubmodelElementCollection<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformProperty(
+            public override Aas.IClass TransformProperty(
                 Aas.IProperty that
             )
             {
@@ -5624,13 +5657,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId = castedValueId;
                 }
 
-                return new EnhancedProperty<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedProperty<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformMultiLanguageProperty(
+            public override Aas.IClass TransformMultiLanguageProperty(
                 Aas.IMultiLanguageProperty that
             )
             {
@@ -5802,13 +5838,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId = castedValueId;
                 }
 
-                return new EnhancedMultiLanguageProperty<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedMultiLanguageProperty<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformRange(
+            public override Aas.IClass TransformRange(
                 Aas.IRange that
             )
             {
@@ -5947,13 +5986,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedRange<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedRange<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformReferenceElement(
+            public override Aas.IClass TransformReferenceElement(
                 Aas.IReferenceElement that
             )
             {
@@ -6106,13 +6148,16 @@ namespace AasCore.Aas3_0_RC02
                     that.Value = castedValue;
                 }
 
-                return new EnhancedReferenceElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedReferenceElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformBlob(
+            public override Aas.IClass TransformBlob(
                 Aas.IBlob that
             )
             {
@@ -6251,13 +6296,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedBlob<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedBlob<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformFile(
+            public override Aas.IClass TransformFile(
                 Aas.IFile that
             )
             {
@@ -6396,13 +6444,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedFile<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedFile<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAnnotatedRelationshipElement(
+            public override Aas.IClass TransformAnnotatedRelationshipElement(
                 Aas.IAnnotatedRelationshipElement that
             )
             {
@@ -6582,13 +6633,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedAnnotatedRelationshipElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAnnotatedRelationshipElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEntity(
+            public override Aas.IClass TransformEntity(
                 Aas.IEntity that
             )
             {
@@ -6774,13 +6828,16 @@ namespace AasCore.Aas3_0_RC02
                     that.SpecificAssetId = castedSpecificAssetId;
                 }
 
-                return new EnhancedEntity<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEntity<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEventPayload(
+            public override Aas.IClass TransformEventPayload(
                 Aas.IEventPayload that
             )
             {
@@ -6855,13 +6912,16 @@ namespace AasCore.Aas3_0_RC02
                     that.SubjectId = castedSubjectId;
                 }
 
-                return new EnhancedEventPayload<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEventPayload<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformBasicEventElement(
+            public override Aas.IClass TransformBasicEventElement(
                 Aas.IBasicEventElement that
             )
             {
@@ -7025,13 +7085,16 @@ namespace AasCore.Aas3_0_RC02
                     that.MessageBroker = castedMessageBroker;
                 }
 
-                return new EnhancedBasicEventElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedBasicEventElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformOperation(
+            public override Aas.IClass TransformOperation(
                 Aas.IOperation that
             )
             {
@@ -7227,13 +7290,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedOperation<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedOperation<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformOperationVariable(
+            public override Aas.IClass TransformOperationVariable(
                 Aas.IOperationVariable that
             )
             {
@@ -7255,13 +7321,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.Value = castedValue;
 
-                return new EnhancedOperationVariable<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedOperationVariable<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformCapability(
+            public override Aas.IClass TransformCapability(
                 Aas.ICapability that
             )
             {
@@ -7400,13 +7469,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedCapability<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedCapability<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformConceptDescription(
+            public override Aas.IClass TransformConceptDescription(
                 Aas.IConceptDescription that
             )
             {
@@ -7526,13 +7598,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedConceptDescription<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedConceptDescription<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformReference(
+            public override Aas.IClass TransformReference(
                 Aas.IReference that
             )
             {
@@ -7573,13 +7648,16 @@ namespace AasCore.Aas3_0_RC02
                     )
                 ).ToList();
 
-                return new EnhancedReference<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedReference<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformKey(
+            public override Aas.IClass TransformKey(
                 Aas.IKey that
             )
             {
@@ -7590,13 +7668,16 @@ namespace AasCore.Aas3_0_RC02
                     );
                 }
 
-                return new EnhancedKey<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedKey<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformLangString(
+            public override Aas.IClass TransformLangString(
                 Aas.ILangString that
             )
             {
@@ -7607,13 +7688,16 @@ namespace AasCore.Aas3_0_RC02
                     );
                 }
 
-                return new EnhancedLangString<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedLangString<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEnvironment(
+            public override Aas.IClass TransformEnvironment(
                 Aas.IEnvironment that
             )
             {
@@ -7681,13 +7765,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedEnvironment<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEnvironment<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEmbeddedDataSpecification(
+            public override Aas.IClass TransformEmbeddedDataSpecification(
                 Aas.IEmbeddedDataSpecification that
             )
             {
@@ -7720,13 +7807,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.DataSpecificationContent = castedDataSpecificationContent;
 
-                return new EnhancedEmbeddedDataSpecification<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEmbeddedDataSpecification<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformValueReferencePair(
+            public override Aas.IClass TransformValueReferencePair(
                 Aas.IValueReferencePair that
             )
             {
@@ -7748,13 +7838,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.ValueId = castedValueId;
 
-                return new EnhancedValueReferencePair<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedValueReferencePair<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformValueList(
+            public override Aas.IClass TransformValueList(
                 Aas.IValueList that
             )
             {
@@ -7781,13 +7874,16 @@ namespace AasCore.Aas3_0_RC02
                     )
                 ).ToList();
 
-                return new EnhancedValueList<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedValueList<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformDataSpecificationIec61360(
+            public override Aas.IClass TransformDataSpecificationIec61360(
                 Aas.IDataSpecificationIec61360 that
             )
             {
@@ -7880,13 +7976,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueList = castedValueList;
                 }
 
-                return new EnhancedDataSpecificationIec61360<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedDataSpecificationIec61360<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformDataSpecificationPhysicalUnit(
+            public override Aas.IClass TransformDataSpecificationPhysicalUnit(
                 Aas.IDataSpecificationPhysicalUnit that
             )
             {
@@ -7913,10 +8012,13 @@ namespace AasCore.Aas3_0_RC02
                     )
                 ).ToList();
 
-                return new EnhancedDataSpecificationPhysicalUnit<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedDataSpecificationPhysicalUnit<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
         }
 
@@ -7928,9 +8030,14 @@ namespace AasCore.Aas3_0_RC02
         {
             private readonly Wrapper<TEnhancement> _wrapper;
 
-            /// <param name="enhancementFactory">how to enhance the instances</param>
+            /// <param name="enhancementFactory">
+            /// <para>how to enhance the instances.</para>
+            ///
+            /// <para>If it returns <c>null</c>, the instance will not be wrapped. However,
+            /// the wrapping will continue recursively.</para>
+            ///</param>
             public Enhancer(
-                System.Func<Aas.IClass, TEnhancement> enhancementFactory
+                System.Func<Aas.IClass, TEnhancement?> enhancementFactory
             )
             {
                 _wrapper = new Wrapper<TEnhancement>(enhancementFactory);
@@ -7983,14 +8090,14 @@ namespace AasCore.Aas3_0_RC02
             /// </returns>
             /// <exception cref="System.ArgumentException">
             /// Thrown when <paramref name="that" /> has been already wrapped
-            /// </exception> 
+            /// </exception>
             public Aas.IClass Wrap(
                 Aas.IClass that
             )
             {
                 var wrapped = _wrapper.Transform(that);
                 return (
-                    wrapped as Aas.IClass
+                    wrapped
                 ) ?? throw new System.InvalidOperationException(
                     "Expected the wrapped instance to be an instance of IClass, " +
                     $"but got: {wrapped}"


### PR DESCRIPTION
It can be wasteful to enhance all the instances in large environments. Therefore, we allow for selective enhancements. To that end, we allow the enhancement factories to return a `null` to signal a missing enhancement.

Generated with [aas-core-codegen 62b7d52].

[aas-core-codegen 62b7d52]: https://github.com/aas-core-works/aas-core-codegen/commit/62b7d52